### PR TITLE
Feature/23 状態異常実装（まひ）

### DIFF
--- a/src/classes/Move/Denjiha.ts
+++ b/src/classes/Move/Denjiha.ts
@@ -1,0 +1,61 @@
+import { Move } from '../Move';
+import { Group } from '../Group';
+import { Pokemon } from '../Pokemon';
+import { GROUP_CLASS_LIST } from '../../utils/datas/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../../utils/datas/statusAilmentDatas';
+
+export class Denjiha extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'でんじは';
+
+  /**
+   * 説明
+   */
+  _description = '相手をまひ状態にする';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '変化';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.denki;
+
+  /**
+   * 威力
+   */
+  _power = null;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 90;
+
+  /**
+   * PP
+   */
+  _pp = 20;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+
+  effects(...pokemons: Pokemon[]): string {
+
+    const [atkPokemon, defPokemon] = pokemons;
+    const resultMessage: string = defPokemon.setStatusAilment(STATUS_AILMENT_CLASS_LIST.saParalysis);
+    return resultMessage;
+
+  }
+}

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -161,7 +161,19 @@ export abstract class Pokemon {
   }
 
   get statusAilment() {
-    return this._statusAilment[0].name;
+    return this._statusAilment[0];
+  }
+
+  setStatusAilment(statusAilment: StatusAilment): string {
+    if (statusAilment === STATUS_AILMENT_CLASS_LIST.saFainting || this._statusAilment.length === 0) {
+      this._statusAilment = [];
+      this._statusAilment.push(statusAilment);      
+      return this._statusAilment[0].getSickedMessage(this, 'sicked');
+    } else if (statusAilment === this._statusAilment[0]) {
+      return this._statusAilment[0].getSickedMessage(this, 'already');
+    } else {
+      return 'しかし、うまくきまらなかった';
+    }
   }
 
   /**

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -1,6 +1,7 @@
 import { basicStatus, IMove, IBattleStatusRank } from '../utils/interface.general';
 import { randomMultipleInArray } from '../utils/functions';
 import { Group } from './Group';
+import { TStatusAilment } from '../utils/type.general';
 
 export abstract class Pokemon {
 
@@ -45,6 +46,8 @@ export abstract class Pokemon {
     accuracy: 0,
     evasion: 0,
   }
+
+  protected _statusAilment: TStatusAilment[] = [];
 
   protected abstract evolve(): Pokemon;
 
@@ -154,6 +157,10 @@ export abstract class Pokemon {
 
   get battleStatusRank() {
     return this._battleStatusRank;
+  }
+
+  get statusAilment() {
+    return this._statusAilment;
   }
 
   /**

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -1,7 +1,8 @@
 import { basicStatus, IMove, IBattleStatusRank } from '../utils/interface.general';
 import { randomMultipleInArray } from '../utils/functions';
 import { Group } from './Group';
-import { TStatusAilment } from '../utils/type.general';
+import { STATUS_AILMENT_CLASS_LIST } from '../utils/datas/statusAilmentDatas';
+import { StatusAilment } from './StatusAilment';
 
 export abstract class Pokemon {
 
@@ -47,7 +48,7 @@ export abstract class Pokemon {
     evasion: 0,
   }
 
-  protected _statusAilment: TStatusAilment[] = [];
+  protected _statusAilment: StatusAilment[] = [];
 
   protected abstract evolve(): Pokemon;
 
@@ -160,7 +161,7 @@ export abstract class Pokemon {
   }
 
   get statusAilment() {
-    return this._statusAilment;
+    return this._statusAilment[0].name;
   }
 
   /**

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -3,6 +3,7 @@ import { randomMultipleInArray } from '../utils/functions';
 import { Group } from './Group';
 import { STATUS_AILMENT_CLASS_LIST } from '../utils/datas/statusAilmentDatas';
 import { StatusAilment } from './StatusAilment';
+import { SaParalysis } from './StatusAilment/SaParalysis';
 
 export abstract class Pokemon {
 
@@ -355,7 +356,7 @@ export abstract class Pokemon {
   /**
    * 種族値・個体値・努力値のステータスを計算して返却
    */
-  calculateBasicStatus(): basicStatus {
+  calculateBasicStatus(key: keyof basicStatus): basicStatus {
     for (let k of Object.keys(this.basicStatus) as (keyof basicStatus)[]) {
       const common = ((this._basicCategoryStatus[k] * 2) + this._basicIndividualStatus[k] + this._basicEffortStatus[k]) * this.lebel / 100;
       this.basicStatus[k] = k === 'hp' 
@@ -363,6 +364,14 @@ export abstract class Pokemon {
         : Math.round(common + 5)
       ;
     }
+
+    // 状態異常がステータスに影響をおよぼす場合は計算
+    switch(this.statusAilment.name) {
+      case 'まひ':
+        this.basicStatus.rapidity /= 2;
+        break;
+    }
+
     return this.basicStatus;
   }
 

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -356,7 +356,7 @@ export abstract class Pokemon {
   /**
    * 種族値・個体値・努力値のステータスを計算して返却
    */
-  calculateBasicStatus(key: keyof basicStatus): basicStatus {
+  calculateBasicStatus(): basicStatus {
     for (let k of Object.keys(this.basicStatus) as (keyof basicStatus)[]) {
       const common = ((this._basicCategoryStatus[k] * 2) + this._basicIndividualStatus[k] + this._basicEffortStatus[k]) * this.lebel / 100;
       this.basicStatus[k] = k === 'hp' 

--- a/src/classes/Pokemon/Basyamo.ts
+++ b/src/classes/Pokemon/Basyamo.ts
@@ -60,6 +60,7 @@ export class Basyamo extends Pokemon {
       this._lebel = this._beforeEvole.lebel;
       this._exPoint = this._beforeEvole.exPoint;
       this._moveList = this._beforeEvole.moveList;
+      this._statusAilment = [this._beforeEvole.statusAilment];
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Jukain.ts
+++ b/src/classes/Pokemon/Jukain.ts
@@ -61,6 +61,7 @@ export class Jukain extends Pokemon {
       this._lebel = this._beforeEvole.lebel;
       this._exPoint = this._beforeEvole.exPoint;
       this._moveList = this._beforeEvole.moveList;
+      this._statusAilment = [this._beforeEvole.statusAilment];
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Juputoru.ts
+++ b/src/classes/Pokemon/Juputoru.ts
@@ -59,6 +59,7 @@ export class Juputoru extends Pokemon {
       this._lebel = this._beforeEvole.lebel;
       this._exPoint = this._beforeEvole.exPoint;
       this._moveList = this._beforeEvole.moveList;
+      this._statusAilment = [this._beforeEvole.statusAilment];
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Mizugorou.ts
+++ b/src/classes/Pokemon/Mizugorou.ts
@@ -17,6 +17,7 @@ export class Mizugorou extends Pokemon {
     {lebel: 1, move: MOVE_CLASS_LIST.taiatari},
     {lebel:1, move: MOVE_CLASS_LIST.nakigoe},
     {lebel:3, move: MOVE_CLASS_LIST.mizudeppou},
+    {lebel:3, move: MOVE_CLASS_LIST.denjiha}
     // {lebel:6, move: 'いわくだき'},
     // {lebel:9, move: 'いわおとし'},
     // {lebel:12, move: 'まもる'},

--- a/src/classes/Pokemon/Numakuro.ts
+++ b/src/classes/Pokemon/Numakuro.ts
@@ -60,6 +60,7 @@ export class Numakuro extends Pokemon {
       this._lebel = this._beforeEvole.lebel;
       this._exPoint = this._beforeEvole.exPoint;
       this._moveList = this._beforeEvole.moveList;
+      this._statusAilment = [this._beforeEvole.statusAilment];
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Raguraji.ts
+++ b/src/classes/Pokemon/Raguraji.ts
@@ -60,6 +60,7 @@ export class Raguraji extends Pokemon {
       this._lebel = this._beforeEvole.lebel;
       this._exPoint = this._beforeEvole.exPoint;
       this._moveList = this._beforeEvole.moveList;
+      this._statusAilment = [this._beforeEvole.statusAilment];
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Raichu.ts
+++ b/src/classes/Pokemon/Raichu.ts
@@ -47,6 +47,7 @@ export class Raichu extends Pokemon {
       this._lebel = this._beforeEvole.lebel;
       this._exPoint = this._beforeEvole.exPoint;
       this._moveList = this._beforeEvole.moveList;
+      this._statusAilment = [this._beforeEvole.statusAilment];
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Wakasyamo.ts
+++ b/src/classes/Pokemon/Wakasyamo.ts
@@ -59,6 +59,8 @@ export class Wakasyamo extends Pokemon {
       this._lebel = this._beforeEvole.lebel;
       this._exPoint = this._beforeEvole.exPoint;
       this._moveList = this._beforeEvole.moveList;
+      this._statusAilment = [this._beforeEvole.statusAilment];
+      this._statusAilment = [this._beforeEvole.statusAilment];
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/StatusAilment.ts
+++ b/src/classes/StatusAilment.ts
@@ -1,0 +1,42 @@
+import { Pokemon } from './Pokemon';
+
+export abstract class StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected abstract _name: string;
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected abstract _sickedMessage: string;
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected abstract _alreadySickedMessage: string;
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected abstract _sickedTurnMessage: string;
+
+  get name() {
+    return this._name;
+  }
+
+  /**
+   * 状態異常になった時、それぞれメッセージを返す処理
+   */
+  getSickedMessage(pokemon: Pokemon, msgGroup: 'sicked' | 'already' | 'turn') {
+    switch(msgGroup) {
+      case 'sicked':
+        return `${pokemon.name}は${this._sickedMessage}`;
+      case 'already':
+        return `${pokemon.name}は${this._alreadySickedMessage}`;
+      case 'turn':
+        return `${pokemon.name}は${this._sickedTurnMessage}`;
+    }
+  }
+}

--- a/src/classes/StatusAilment/SaParalysis.ts
+++ b/src/classes/StatusAilment/SaParalysis.ts
@@ -1,6 +1,6 @@
 import { StatusAilment } from '../StatusAilment';
 
-class saParalysis extends StatusAilment {
+export class SaParalysis extends StatusAilment {
 
   /**
    * 名前
@@ -21,5 +21,5 @@ class saParalysis extends StatusAilment {
    * 状態異常のままターンになったときのメッセージ
    */
   protected _sickedTurnMessage: string = 'からだがしびれてうごない';
-  
+
 }

--- a/src/classes/StatusAilment/SaParalysis.ts
+++ b/src/classes/StatusAilment/SaParalysis.ts
@@ -1,0 +1,25 @@
+import { StatusAilment } from '../StatusAilment';
+
+class saParalysis extends StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected _name: string = 'まひ';
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected _sickedMessage: string = 'まひしてわざが出にくくなった';
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected _alreadySickedMessage: string = 'すでにまひしている';
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected _sickedTurnMessage: string = 'からだがしびれてうごない';
+  
+}

--- a/src/utils/datas/moveClassDatas.ts
+++ b/src/utils/datas/moveClassDatas.ts
@@ -7,6 +7,7 @@ import { Hikkaku } from '../../classes/Move/Hikkaku';
 import { Konoha } from '../../classes/Move/Konoha';
 import { Hinoko } from '../../classes/Move/Hinoko';
 import { MizuDeppou } from '../../classes/Move/MizuDeppou';
+import { Denjiha } from '../../classes/Move/Denjiha';
 import { Move } from '../../classes/Move';
 
 export const MOVE_CLASS_LIST: {
@@ -21,7 +22,7 @@ export const MOVE_CLASS_LIST: {
   "denkouSekka": new Nakigoe(),
   "aianTeru": new Nakigoe(),
   "taiatari": new Taiatari(),
-  "denziha": new Nakigoe(),
+  "denjiha": new Denjiha(),
   "speedStar": new Nakigoe(),
   "yadorigiNoTane": new Nakigoe(),
   "tsuruNoMuchi": new Nakigoe(),

--- a/src/utils/datas/statusAilmentDatas.ts
+++ b/src/utils/datas/statusAilmentDatas.ts
@@ -1,0 +1,13 @@
+import { SaParalysis } from '../../classes/StatusAilment/SaParalysis';
+import { StatusAilment } from '../../classes/StatusAilment';
+
+export const STATUS_AILMENT_CLASS_LIST: {
+  [key: string]: StatusAilment;
+} = {
+  'saBurn': new SaParalysis(),
+  'saFreeze': new SaParalysis(),
+  'saParalysis': new SaParalysis(),
+  'saPoison': new SaParalysis(),
+  'saSleep': new SaParalysis(),
+  'saFainting': new SaParalysis()
+}

--- a/src/utils/type.general.ts
+++ b/src/utils/type.general.ts
@@ -1,1 +1,0 @@
-export type TStatusAilment = 'saBurn' | 'saFreeze' | 'saParalysis' | 'saPoison' | 'saSleep' | 'saFainting';

--- a/src/utils/type.general.ts
+++ b/src/utils/type.general.ts
@@ -1,0 +1,1 @@
+export type TStatusAilment = 'saBurn' | 'saFreeze' | 'saParalysis' | 'saPoison' | 'saSleep' | 'saFainting';


### PR DESCRIPTION
## 行ったこと
* [状態異常の実装〜まひ〜](https://s-yqual.com/blog/1163)

## 概要
* ステータス異常用のクラスを作成
* ポケモンにステータス異常を保持するクラスを持たせる
* ステータス異常は進化した際も引き継ぐようにする
* ステータス異常が基本ステータスに影響する場合の処理を追加する

## 使い方
* ミズゴロウを選択してでんじはを行う
* まひ状態がレンダリングされていれば成功

## UIに対する変更
* https://user-images.githubusercontent.com/36039518/105863542-55dc5100-6034-11eb-9cdd-2edaebc38744.mov

## その他
* わけわかんなくなってきた。
* それぞれのインスタンスが密接に関わりすぎていて、どのインスタンスでどの領域までカバーするのがかなりわかりづらい。