### PR TITLE
Feature/26 hp計算

### DIFF
--- a/src/classes/BattleController.ts
+++ b/src/classes/BattleController.ts
@@ -83,18 +83,27 @@ export class BattleController {
 
         if (this.checkFirstMove(pokemonMove, enemyAiMove)) {
           enemyDamage = this.tatakauAction(this.pokemon, this.enemy, pokemonMove);
+          this.enemy.calculateRemainingHp('sub', enemyDamage);
           pokemonDamage = this.tatakauAction(this.enemy, this.pokemon, enemyAiMove);
+          this.pokemon.calculateRemainingHp('sub', pokemonDamage);
         } else {
           pokemonDamage = this.tatakauAction(this.enemy, this.pokemon, enemyAiMove);
+          this.pokemon.calculateRemainingHp('sub', pokemonDamage);
           enemyDamage = this.tatakauAction(this.pokemon, this.enemy, pokemonMove);
+          this.enemy.calculateRemainingHp('sub', enemyDamage);
         }
         // ステータス確認用
-        // console.log(enemyDamage);
-        // console.log(this.pokemon.battleStatusRank);
-        // console.log(this.pokemon.statusAilment);
+        // console.log(this.pokemon.basicStatus);
         // console.log(pokemonDamage);
-        // console.log(this.enemy.battleStatusRank);
-        // console.log(this.enemy.statusAilment);
+        // // console.log(this.pokemon.battleStatusRank);
+        // // console.log(this.pokemon.statusAilment);
+        // console.log(this.pokemon.remainingHp);
+
+        // console.log(this.pokemon.basicStatus);
+        // console.log(enemyDamage);
+        // // console.log(this.enemy.battleStatusRank);
+        // // console.log(this.enemy.statusAilment);
+        // console.log(this.pokemon.remainingHp);
       });
     });
 
@@ -110,14 +119,19 @@ export class BattleController {
         this.runCount++;
         this.controller.view.renderSerif(`${this.enemy.name}からにげられなかった`);
         pokemonDamage = this.tatakauAction(this.enemy, this.pokemon, enemyAiMove);
+        this.pokemon.calculateRemainingHp('sub', pokemonDamage);
       }
       // ステータス確認用
-      // console.log(enemyDamage);
+      // console.log(this.pokemon.basicStatus);
+      // console.log(pokemonDamage);
       // console.log(this.pokemon.battleStatusRank);
       // console.log(this.pokemon.statusAilment);
-      // console.log(pokemonDamage);
+      // console.log(this.pokemon.remainingHp);
+      // console.log(this.pokemon.basicStatus);
+      // console.log(enemyDamage);
       // console.log(this.enemy.battleStatusRank);
       // console.log(this.enemy.statusAilment);
+      // console.log(this.pokemon.remainingHp);
     });
   }
 

--- a/src/classes/BattleController.ts
+++ b/src/classes/BattleController.ts
@@ -61,7 +61,7 @@ export class BattleController {
         e.preventDefault();
 
         const index = Number((<HTMLButtonElement>e.target).id.slice(-1));
-        const pokemonMove: Move = this.pokemon.moveList[index].move;
+        const pokemonMove: Move = this.pokemon.moveList[index].move;        
 
         if (this.checkFirstMove(pokemonMove, enemyAiMove)) {
           enemyDamage = this.tatakauAction(this.pokemon, this.enemy, pokemonMove);
@@ -134,6 +134,34 @@ export class BattleController {
       // console.log(this.enemy.statusAilment);
       // console.log(this.pokemon.remainingHp);
       // console.log(this.pokemon.statusAilment);
+    });
+  }
+
+  // 所定のロジックで確認して、順位をつける関数を作成
+  checkMoveOrder(pokemonMove: { pokemon: Pokemon, move: Move }[]): { pokemon: Pokemon, move: Move }[] {
+
+    return pokemonMove.sort((next, cur) => {
+
+      // わざの優先度を確認
+      if (next.move.priority !== cur.move.priority) {
+        if (next.move.priority < cur.move.priority) return 1;
+        if (next.move.priority > cur.move.priority) return -1;
+      }
+
+      // ポケモンのすばやさを確認
+      if (next.pokemon.calculateBasicStatus(true).rapidity !== cur.pokemon.calculateBasicStatus(true).rapidity) {
+        if (next.pokemon.calculateBasicStatus(true).rapidity < cur.pokemon.calculateBasicStatus(true).rapidity) return 1;
+        if (next.pokemon.calculateBasicStatus(true).rapidity > cur.pokemon.calculateBasicStatus(true).rapidity) return -1;
+      }
+
+      // ランダム確認
+      const randomNum = Math.floor(Math.random() * 2);
+      if (randomNum === 0) {
+        return 1;
+      } else {
+        return -1;
+      }
+
     });
   }
 

--- a/src/classes/BattleController.ts
+++ b/src/classes/BattleController.ts
@@ -6,8 +6,6 @@ import { Achamo } from '../classes/Pokemon/Achamo';
 import { Mizugorou } from '../classes/Pokemon/Mizugorou';
 import { Kimori } from '../classes/Pokemon/Kimori';
 import { Controller } from './Controller';
-import { MOVE_CLASS_LIST } from '../utils/datas/moveClassDatas';
-import { Nakigoe } from './Move/Nakigoe';
 
 export class BattleController {
 
@@ -70,24 +68,36 @@ export class BattleController {
           this.enemy.calculateRemainingHp('sub', enemyDamage);
           pokemonDamage = this.tatakauAction(this.enemy, this.pokemon, enemyAiMove);
           this.pokemon.calculateRemainingHp('sub', pokemonDamage);
+
+          if (this.checkPokemonSaFainting(this.pokemon)) {
+            this.controller.view.hideBattleField();
+            this.controller.view.showMainField();
+            this.controller.view.renderSerif(`${this.pokemon.name}はたおれた。hpがゼロになったので、バトルが終了した！`);
+          }
         } else {
           pokemonDamage = this.tatakauAction(this.enemy, this.pokemon, enemyAiMove);
           this.pokemon.calculateRemainingHp('sub', pokemonDamage);
           enemyDamage = this.tatakauAction(this.pokemon, this.enemy, pokemonMove);
           this.enemy.calculateRemainingHp('sub', enemyDamage);
+
+          if (this.checkPokemonSaFainting(this.enemy)) {
+            this.controller.view.hideBattleField();
+            this.controller.view.showMainField();
+            this.controller.view.renderSerif(`${this.enemy.name}はたおれた。hpがゼロになったので、バトルが終了した！`);
+          }
         }
         // ステータス確認用
         // console.log(this.pokemon.basicStatus);
         // console.log(pokemonDamage);
         // // console.log(this.pokemon.battleStatusRank);
-        // // console.log(this.pokemon.statusAilment);
+        // console.log(this.pokemon.statusAilment?.name);
         // console.log(this.pokemon.remainingHp);
 
         // console.log(this.pokemon.basicStatus);
         // console.log(enemyDamage);
         // // console.log(this.enemy.battleStatusRank);
-        // // console.log(this.enemy.statusAilment);
-        // console.log(this.pokemon.remainingHp);
+        // console.log(this.enemy.statusAilment?.name);
+        // console.log(this.enemy.remainingHp);
       });
     });
 
@@ -104,6 +114,12 @@ export class BattleController {
         this.controller.view.renderSerif(`${this.enemy.name}からにげられなかった`);
         pokemonDamage = this.tatakauAction(this.enemy, this.pokemon, enemyAiMove);
         this.pokemon.calculateRemainingHp('sub', pokemonDamage);
+
+        if (this.checkPokemonSaFainting(this.pokemon)) {
+          this.controller.view.hideBattleField();
+          this.controller.view.showMainField();
+          this.controller.view.renderSerif(`hpがゼロになったので、バトルが終了した！`);
+        }
       }
       // ステータス確認用
       // console.log(this.pokemon.basicStatus);
@@ -111,12 +127,23 @@ export class BattleController {
       // console.log(this.pokemon.battleStatusRank);
       // console.log(this.pokemon.statusAilment);
       // console.log(this.pokemon.remainingHp);
+      // console.log(this.pokemon.statusAilment);
       // console.log(this.pokemon.basicStatus);
       // console.log(enemyDamage);
       // console.log(this.enemy.battleStatusRank);
       // console.log(this.enemy.statusAilment);
       // console.log(this.pokemon.remainingHp);
+      // console.log(this.pokemon.statusAilment);
     });
+  }
+
+  checkPokemonSaFainting(pokemon: Pokemon): boolean {
+    if (pokemon.statusAilment?.name === 'ひんし') {
+      console.log(true);
+      return true;
+    }
+    console.log(false);
+    return false;
   }
 
   tatakauAction(atkPokemon: Pokemon, defPokemon: Pokemon, move: Move): number {

--- a/src/classes/BattleController.ts
+++ b/src/classes/BattleController.ts
@@ -38,22 +38,6 @@ export class BattleController {
     this.setBattleSystem();
   }
 
-  // setRunAction() {
-  //   const trigger = document.querySelector('#a-nigeru') as HTMLButtonElement;
-  //   trigger.addEventListener('click', (e) => {
-  //     e.preventDefault();
-
-  //     if (this.checkRun()) {
-  //       this.controller.view.hideBattleField();
-  //       this.controller.view.showMainField();
-  //       this.controller.view.renderSerif(`${this.enemy.name}からにげることができた`);
-  //     } else {
-  //       this.runCount++;
-  //       this.controller.view.renderSerif(`${this.enemy.name}からにげられなかった`);
-  //     }
-  //   });
-  // }
-
   setBattleSystem() {
 
     const addedTrigger = document.querySelector('#action_field') as HTMLButtonElement;

--- a/src/classes/BattleController.ts
+++ b/src/classes/BattleController.ts
@@ -60,8 +60,6 @@ export class BattleController {
 
     // 敵ポケモンがわざを選択
     const enemyAiMove: Move = this.selectAiMove(this.enemy);
-    let enemyDamage: number = 0;
-    let pokemonDamage: number = 0;
 
     // たたかうを選択したとき
     actionTriggers.forEach(trigger => {
@@ -114,14 +112,17 @@ export class BattleController {
       } else {
         this.runCount++;
         this.controller.view.renderSerif(`${this.enemy.name}からにげられなかった`);
-        pokemonDamage = this.tatakauAction(this.enemy, this.pokemon, enemyAiMove);
-        this.pokemon.calculateRemainingHp('sub', pokemonDamage);
 
-        if (this.checkPokemonSaFainting(this.pokemon)) {
-          this.controller.view.hideBattleField();
-          this.controller.view.showMainField();
-          this.controller.view.renderSerif(`hpがゼロになったので、バトルが終了した！`);
+        const enemyMoveData: MoveActionSet = {
+          pokemon: this.enemy,
+          enemy: this.pokemon,
+          move: enemyAiMove
         }
+
+        actionPokemons.push(enemyMoveData);
+
+        const checkedMoveOrderPokemons = this.checkMoveOrder(actionPokemons);
+        this.actionExecute(checkedMoveOrderPokemons);
       }
       // ステータス確認用
       // console.log(this.pokemon.basicStatus);

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -12,11 +12,15 @@ export abstract class Pokemon {
 
   protected abstract _groups: Group[];
 
-  protected abstract _moveList: IMove[];
   protected abstract _moveListToRequest: IMove[];
   protected abstract _initialLebel: number[];
-  protected abstract _lebel: number;
-  protected abstract _exPoint: number;
+  // protected abstract _moveList: IMove[];
+  // protected abstract _lebel: number;
+  // protected abstract _exPoint: number;
+
+  _lebel: number = 0;
+  _exPoint: number = 0;
+  _moveList: IMove[] = [];
 
   protected abstract _basicCategoryStatus: basicStatus;
   protected _basicIndividualStatus: basicStatus;
@@ -47,6 +51,8 @@ export abstract class Pokemon {
     accuracy: 0,
     evasion: 0,
   }
+
+  protected _remainingHp: number = this.basicStatus.hp;
 
   protected _statusAilment: StatusAilment[] = [];
 
@@ -162,6 +168,22 @@ export abstract class Pokemon {
 
   get statusAilment() {
     return this._statusAilment[0] ?? null;
+  }
+
+  get remainingHp() {
+    return this._remainingHp;
+  }
+
+  takeOverPokemonData(beforeEvolvePokemon: Pokemon) {
+    this._nickname = beforeEvolvePokemon.nickname;
+    this._basicEffortStatus =beforeEvolvePokemon.basicEffortStatus;
+    this._basicIndividualStatus =beforeEvolvePokemon.basicIndividualStatus;
+
+    this._lebel =beforeEvolvePokemon.lebel;
+    this._exPoint =beforeEvolvePokemon.exPoint;
+    this._moveList =beforeEvolvePokemon.moveList;
+    this._statusAilment = [beforeEvolvePokemon.statusAilment];
+    this._remainingHp =beforeEvolvePokemon.remainingHp;
   }
 
   setStatusAilment(statusAilment: StatusAilment): string {

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -112,12 +112,14 @@ export abstract class Pokemon {
 
     if (this.getReqLebelUpExPoint() <= this.exPoint) {
 
+      const beforeHp = this.basicStatus.hp;
       this.lebel ++;
-      this.lebelUpAction();
+      this.lebelUpAction(beforeHp);
 
       while (this.getReqLebelUpExPoint() < 0) {
+        const beforeHp = this.basicStatus.hp;
         this.lebel ++;
-        this.lebelUpAction();
+        this.lebelUpAction(beforeHp);
       }
 
     }
@@ -184,7 +186,11 @@ export abstract class Pokemon {
     this._exPoint =beforeEvolvePokemon.exPoint;
     this._moveList =beforeEvolvePokemon.moveList;
     this._statusAilment = [beforeEvolvePokemon.statusAilment];
-    this._remainingHp =beforeEvolvePokemon.remainingHp;
+
+    // 現在のHPに合わせてレベルアップ後のHPを調整
+    if (this.statusAilment?.name !== 'ひんし') {
+      this._remainingHp = this.calculateRemainingHp('add', this.basicStatus.hp - beforeEvolvePokemon.remainingHp);
+    }
   }
 
   resetStatusAilment(): void {
@@ -213,9 +219,16 @@ export abstract class Pokemon {
   }
 
   /**
-   * レベルが上がったときの処理（新しい技を覚える）
+   * レベルが上がったときの処理
    */
-  lebelUpAction(): void {
+  protected lebelUpAction(beforeHp: number): void {
+
+    // 現在のHPに合わせてレベルアップ後のHPを調整
+    if (this.statusAilment?.name !== 'ひんし') {
+      this.remainingHp = this.calculateRemainingHp('add', this.basicStatus.hp - beforeHp);
+    }
+
+    // 習得できるわざがあるかの確認
     const requestableMoveList: IMove[] = this.moveListToRequest.filter(moveList => moveList.lebel === this.lebel);
     if (requestableMoveList.length >= 1) {
       requestableMoveList.forEach(requestableMove => this.requestNewMove(requestableMove));

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -14,9 +14,6 @@ export abstract class Pokemon {
 
   protected abstract _moveListToRequest: IMove[];
   protected abstract _initialLebel: number[];
-  // protected abstract _moveList: IMove[];
-  // protected abstract _lebel: number;
-  // protected abstract _exPoint: number;
 
   _lebel: number = 0;
   _exPoint: number = 0;
@@ -52,7 +49,7 @@ export abstract class Pokemon {
     evasion: 0,
   }
 
-  protected _remainingHp: number = this.basicStatus.hp;
+  protected abstract _remainingHp: number;
 
   protected _statusAilment: StatusAilment[] = [];
 
@@ -174,6 +171,10 @@ export abstract class Pokemon {
     return this._remainingHp;
   }
 
+  set remainingHp(number) {
+    this._remainingHp = number;
+  }
+
   takeOverPokemonData(beforeEvolvePokemon: Pokemon) {
     this._nickname = beforeEvolvePokemon.nickname;
     this._basicEffortStatus =beforeEvolvePokemon.basicEffortStatus;
@@ -184,6 +185,10 @@ export abstract class Pokemon {
     this._moveList =beforeEvolvePokemon.moveList;
     this._statusAilment = [beforeEvolvePokemon.statusAilment];
     this._remainingHp =beforeEvolvePokemon.remainingHp;
+  }
+
+  resetStatusAilment(): void {
+    this._statusAilment = [];
   }
 
   setStatusAilment(statusAilment: StatusAilment): string {
@@ -215,6 +220,35 @@ export abstract class Pokemon {
     if (requestableMoveList.length >= 1) {
       requestableMoveList.forEach(requestableMove => this.requestNewMove(requestableMove));
     }
+  }
+
+
+  /**
+   * 残りhpの計算
+   */
+  calculateRemainingHp(effect: 'saFainting' | 'sub' | 'add' | 'reset', number: number): number {
+    switch (effect) {
+      case 'add':
+        this.remainingHp += number;
+        break;
+      case 'sub':
+        this.remainingHp -= number;
+        break;
+      case 'reset':
+        this.remainingHp = this.basicStatus.hp;
+        this.resetStatusAilment();
+        break;
+      case 'saFainting':
+        this.remainingHp = 0;
+        this.remainingHp = this.remainingHp > this.basicStatus.hp 
+          ? this.basicStatus.hp
+          : this.remainingHp;
+    }
+
+    if (this.remainingHp === 0) {
+      this.setStatusAilment(STATUS_AILMENT_CLASS_LIST.saFainting);
+    }
+    return this.remainingHp;
   }
 
 

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -245,8 +245,9 @@ export abstract class Pokemon {
           : this.remainingHp;
     }
 
-    if (this.remainingHp === 0) {
+    if (this.remainingHp <= 0) {
       this.setStatusAilment(STATUS_AILMENT_CLASS_LIST.saFainting);
+      this.remainingHp = 0;
     }
     return this.remainingHp;
   }

--- a/src/classes/Pokemon/Achamo.ts
+++ b/src/classes/Pokemon/Achamo.ts
@@ -39,9 +39,6 @@ export class Achamo extends Pokemon {
     SPprotected: 50,
     rapidity: 45
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);

--- a/src/classes/Pokemon/Achamo.ts
+++ b/src/classes/Pokemon/Achamo.ts
@@ -39,6 +39,7 @@ export class Achamo extends Pokemon {
     SPprotected: 50,
     rapidity: 45
   };
+  _remainingHp: number;
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -50,6 +51,7 @@ export class Achamo extends Pokemon {
     this._moveList = this.getInitialMoveList(this.lebel);
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Basyamo.ts
+++ b/src/classes/Pokemon/Basyamo.ts
@@ -43,24 +43,13 @@ export class Basyamo extends Pokemon {
     SPprotected: 70,
     rapidity: 80
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
 
     if (this._beforeEvole) {
       this.render(`${this.name}に進化した。`);
-
-      this._nickname = this._beforeEvole.nickname;
-      this._basicEffortStatus = this._beforeEvole.basicEffortStatus;
-      this._basicIndividualStatus = this._beforeEvole.basicIndividualStatus;
-
-      this._lebel = this._beforeEvole.lebel;
-      this._exPoint = this._beforeEvole.exPoint;
-      this._moveList = this._beforeEvole.moveList;
-      this._statusAilment = [this._beforeEvole.statusAilment];
+      this.takeOverPokemonData(this._beforeEvole);
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Basyamo.ts
+++ b/src/classes/Pokemon/Basyamo.ts
@@ -43,6 +43,7 @@ export class Basyamo extends Pokemon {
     SPprotected: 70,
     rapidity: 80
   };
+  _remainingHp: number;
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -57,6 +58,7 @@ export class Basyamo extends Pokemon {
     }
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Jukain.ts
+++ b/src/classes/Pokemon/Jukain.ts
@@ -44,9 +44,7 @@ export class Jukain extends Pokemon {
     SPprotected: 85,
     rapidity: 145
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
+  _remainingHp: number;
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -70,6 +68,7 @@ export class Jukain extends Pokemon {
     }
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Jukain.ts
+++ b/src/classes/Pokemon/Jukain.ts
@@ -62,6 +62,7 @@ export class Jukain extends Pokemon {
       this._exPoint = this._beforeEvole.exPoint;
       this._moveList = this._beforeEvole.moveList;
       this._statusAilment = [this._beforeEvole.statusAilment];
+      this._remainingHp = this._beforeEvole.remainingHp;
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Juputoru.ts
+++ b/src/classes/Pokemon/Juputoru.ts
@@ -42,24 +42,13 @@ export class Juputoru extends Pokemon {
     SPprotected: 65,
     rapidity: 95
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
-
+  
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
 
     if (this._beforeEvole) {
       this.render(`${this.name}に進化した。`);
-
-      this._nickname = this._beforeEvole.nickname;
-      this._basicEffortStatus = this._beforeEvole.basicEffortStatus;
-      this._basicIndividualStatus = this._beforeEvole.basicIndividualStatus;
-
-      this._lebel = this._beforeEvole.lebel;
-      this._exPoint = this._beforeEvole.exPoint;
-      this._moveList = this._beforeEvole.moveList;
-      this._statusAilment = [this._beforeEvole.statusAilment];
+      this.takeOverPokemonData(this._beforeEvole);
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Juputoru.ts
+++ b/src/classes/Pokemon/Juputoru.ts
@@ -42,6 +42,7 @@ export class Juputoru extends Pokemon {
     SPprotected: 65,
     rapidity: 95
   };
+  _remainingHp: number;
   
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -56,6 +57,7 @@ export class Juputoru extends Pokemon {
     }
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Kimori.ts
+++ b/src/classes/Pokemon/Kimori.ts
@@ -39,9 +39,6 @@ export class Kimori extends Pokemon {
     SPprotected: 55,
     rapidity: 70
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);

--- a/src/classes/Pokemon/Kimori.ts
+++ b/src/classes/Pokemon/Kimori.ts
@@ -39,6 +39,7 @@ export class Kimori extends Pokemon {
     SPprotected: 55,
     rapidity: 70
   };
+  _remainingHp: number;
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -50,6 +51,7 @@ export class Kimori extends Pokemon {
     this._moveList = this.getInitialMoveList(this.lebel);
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Mizugorou.ts
+++ b/src/classes/Pokemon/Mizugorou.ts
@@ -40,9 +40,6 @@ export class Mizugorou extends Pokemon {
     SPprotected: 50,
     rapidity: 40
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);

--- a/src/classes/Pokemon/Mizugorou.ts
+++ b/src/classes/Pokemon/Mizugorou.ts
@@ -40,6 +40,7 @@ export class Mizugorou extends Pokemon {
     SPprotected: 50,
     rapidity: 40
   };
+  _remainingHp: number;
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -51,6 +52,7 @@ export class Mizugorou extends Pokemon {
     this._moveList = this.getInitialMoveList(this.lebel);
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Numakuro.ts
+++ b/src/classes/Pokemon/Numakuro.ts
@@ -43,24 +43,13 @@ export class Numakuro extends Pokemon {
     SPprotected: 70,
     rapidity: 50
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
 
     if (this._beforeEvole) {
       this.render(`${this.name}に進化した。`);
-
-      this._nickname = this._beforeEvole.nickname;
-      this._basicEffortStatus = this._beforeEvole.basicEffortStatus;
-      this._basicIndividualStatus = this._beforeEvole.basicIndividualStatus;
-
-      this._lebel = this._beforeEvole.lebel;
-      this._exPoint = this._beforeEvole.exPoint;
-      this._moveList = this._beforeEvole.moveList;
-      this._statusAilment = [this._beforeEvole.statusAilment];
+      this.takeOverPokemonData(this._beforeEvole);
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Numakuro.ts
+++ b/src/classes/Pokemon/Numakuro.ts
@@ -43,6 +43,7 @@ export class Numakuro extends Pokemon {
     SPprotected: 70,
     rapidity: 50
   };
+  _remainingHp: number;
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -57,6 +58,7 @@ export class Numakuro extends Pokemon {
     }
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Pikachu.ts
+++ b/src/classes/Pokemon/Pikachu.ts
@@ -31,9 +31,7 @@ export class Pikachu extends Pokemon {
     SPprotected: 50,
     rapidity: 90
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
+  _remainingHp: number;
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -45,7 +43,7 @@ export class Pikachu extends Pokemon {
     this._moveList = this.getInitialMoveList(this.lebel);
 
     this._basicStatus = this.calculateBasicStatus();
-
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Raguraji.ts
+++ b/src/classes/Pokemon/Raguraji.ts
@@ -43,24 +43,13 @@ export class Raguraji extends Pokemon {
     SPprotected: 90,
     rapidity: 60
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
-
+  
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
 
     if (this._beforeEvole) {
       this.render(`${this.name}に進化した。`);
-
-      this._nickname = this._beforeEvole.nickname;
-      this._basicEffortStatus = this._beforeEvole.basicEffortStatus;
-      this._basicIndividualStatus = this._beforeEvole.basicIndividualStatus;
-
-      this._lebel = this._beforeEvole.lebel;
-      this._exPoint = this._beforeEvole.exPoint;
-      this._moveList = this._beforeEvole.moveList;
-      this._statusAilment = [this._beforeEvole.statusAilment];
+      this.takeOverPokemonData(this._beforeEvole);
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Raguraji.ts
+++ b/src/classes/Pokemon/Raguraji.ts
@@ -43,6 +43,7 @@ export class Raguraji extends Pokemon {
     SPprotected: 90,
     rapidity: 60
   };
+  _remainingHp: number;
   
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -57,6 +58,7 @@ export class Raguraji extends Pokemon {
     }
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Raichu.ts
+++ b/src/classes/Pokemon/Raichu.ts
@@ -30,24 +30,13 @@ export class Raichu extends Pokemon {
     SPprotected: 80,
     rapidity: 110
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
 
     if (this._beforeEvole) {
       this.render(`${this.name}に進化した。`);
-
-      this._nickname = this._beforeEvole.nickname;
-      this._basicEffortStatus = this._beforeEvole.basicEffortStatus;
-      this._basicIndividualStatus = this._beforeEvole.basicIndividualStatus;
-
-      this._lebel = this._beforeEvole.lebel;
-      this._exPoint = this._beforeEvole.exPoint;
-      this._moveList = this._beforeEvole.moveList;
-      this._statusAilment = [this._beforeEvole.statusAilment];
+      this.takeOverPokemonData(this._beforeEvole);
     } else {
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);

--- a/src/classes/Pokemon/Raichu.ts
+++ b/src/classes/Pokemon/Raichu.ts
@@ -30,6 +30,7 @@ export class Raichu extends Pokemon {
     SPprotected: 80,
     rapidity: 110
   };
+  _remainingHp: number;
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -44,6 +45,7 @@ export class Raichu extends Pokemon {
     }
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   evolve() {

--- a/src/classes/Pokemon/Wakasyamo.ts
+++ b/src/classes/Pokemon/Wakasyamo.ts
@@ -42,6 +42,7 @@ export class Wakasyamo extends Pokemon {
     SPprotected: 60,
     rapidity: 55
   };
+  _remainingHp: number;
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
@@ -57,6 +58,7 @@ export class Wakasyamo extends Pokemon {
     }
 
     this._basicStatus = this.calculateBasicStatus();
+    this._remainingHp = this.basicStatus.hp;
   }
 
   protected evolve(): Pokemon {

--- a/src/classes/Pokemon/Wakasyamo.ts
+++ b/src/classes/Pokemon/Wakasyamo.ts
@@ -42,26 +42,15 @@ export class Wakasyamo extends Pokemon {
     SPprotected: 60,
     rapidity: 55
   };
-  _lebel: number;
-  _exPoint: number;
-  _moveList: IMove[];
 
   constructor(_beforeEvole: Pokemon | null, _nickname?: string) {
     super(_beforeEvole, _nickname);
 
     if (this._beforeEvole) {
       this.render(`${this.name}に進化した。`);
-
-      this._nickname = this._beforeEvole.nickname;
-      this._basicEffortStatus = this._beforeEvole.basicEffortStatus;
-      this._basicIndividualStatus = this._beforeEvole.basicIndividualStatus;
-
-      this._lebel = this._beforeEvole.lebel;
-      this._exPoint = this._beforeEvole.exPoint;
-      this._moveList = this._beforeEvole.moveList;
-      this._statusAilment = [this._beforeEvole.statusAilment];
-      this._statusAilment = [this._beforeEvole.statusAilment];
+      this.takeOverPokemonData(this._beforeEvole);
     } else {
+
       this._lebel = randomSingleInArray<number>(this._initialLebel);
       this._exPoint = Math.pow(this.lebel, 3);
       this._moveList = this.getInitialMoveList(this.lebel);

--- a/src/classes/StatusAilment/SaFainting.ts
+++ b/src/classes/StatusAilment/SaFainting.ts
@@ -1,0 +1,30 @@
+import { StatusAilment } from '../StatusAilment';
+
+export class SaFainting extends StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected _name: string = 'ひんし';
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected _sickedMessage: string = 'たおれた';
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected _alreadySickedMessage: string = 'ひんしでうごけない';
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected _sickedTurnMessage: string = 'ひんしでうごけない';
+
+  /**
+   * 状態異常が回復したときのメッセージ
+   */
+  protected _sickedRecoceryMessage = 'ひんしから回復した';
+
+}

--- a/src/utils/datas/statusAilmentDatas.ts
+++ b/src/utils/datas/statusAilmentDatas.ts
@@ -5,6 +5,7 @@ import { SaPoison } from '../../classes/StatusAilment/SaPoison';
 import { SaFreeze } from '../../classes/StatusAilment/SaFreeze';
 import { SaSleep } from '../../classes/StatusAilment/SaSleep';
 import { SaBurn } from '../../classes/StatusAilment/SaBurn';
+import { SaFainting } from '../../classes/StatusAilment/SaFainting';
 
 export const STATUS_AILMENT_CLASS_LIST: {
   [key: string]: StatusAilment;
@@ -15,5 +16,5 @@ export const STATUS_AILMENT_CLASS_LIST: {
   'saPoison': new SaPoison(),
   'saBadPoison': new SaBadPoison(),
   'saSleep': new SaSleep(),
-  'saFainting': new SaParalysis()
+  'saFainting': new SaFainting()
 }


### PR DESCRIPTION
## 行ったこと
* https://s-yqual.com/blog/1182

## 概要
* こうげき内容によって、残りHPを計算させる。
* どちらかのHPが0になったら、状態異常ひんしとし、バトルを終了して画面のレンダリングをやめる。

## 使い方
* ポケモンバトルを行い、どちらかのHPがゼロになるまで、適当なアクションを実行する
* HPのリセットはできていないため、再度バトル画面へ行くとバグる。

## UIに対する変更
* https://user-images.githubusercontent.com/36039518/106351801-d2677c00-6321-11eb-8165-d570d408891b.mov

## その他
* こうげきアクションのリファクタリングをする際、複数条件によって順番を決めるそーと機能で迷った。JSのsortでうまいこといった。