### PR TITLE
Feature/設計見直し ポケモンクラス実装

### DIFF
--- a/src/model/ExceptPokemon.ts
+++ b/src/model/ExceptPokemon.ts
@@ -2,11 +2,14 @@ import { Pokemon } from "../model/pokemon/Pokemon";
 import { ILebel } from '../utils/interface/ILebel';
 import { IStatus } from '../utils/interface/IStatus';
 import { IMoveList } from '../utils/interface/IMoveList';
+import { IPokemonBattle } from '../utils/interface/IPokemonBattle';
 import { TBasicStatus } from '../utils/type/TBasicStatus';
+import { TBattleStatusRank } from '../utils/type/TBattleStatusRank';
 import { Move } from '../model/move/Move';
 import { randomMultipleInArray } from '../utils/general';
+import { StatusAilment } from '../model/statusAilment/StatusAilment';
 
-export class ExceptPokemon implements ILebel, IStatus, IMoveList {
+export class ExceptPokemon implements ILebel, IStatus, IMoveList, IPokemonBattle {
 
   /**
    * ポケモン
@@ -38,6 +41,30 @@ export class ExceptPokemon implements ILebel, IStatus, IMoveList {
   };
   _basicTotalStatus: TBasicStatus;
 
+  /**
+   * 残りHP
+   */
+  _remainingHp: number;
+
+  /**
+   * 状態異常
+   */
+  _statusAilment: StatusAilment[] = [];
+
+  /**
+   * バトルステータスランク
+   */
+  _battleStatusRank: TBattleStatusRank = {
+    attack: 0,
+    protected: 0,
+    SPattack: 0,
+    SPprotected: 0,
+    rapidity: 0,
+    critical: 0,
+    accuracy: 0,
+    evasion: 0
+  };
+
   constructor(pokemon: Pokemon, lebel: number) {
     this._pokemon = pokemon;
     this._lebel = lebel;
@@ -45,6 +72,8 @@ export class ExceptPokemon implements ILebel, IStatus, IMoveList {
     this._basicPokemonStatus = this._pokemon.basicPokemonStatus;
     this._basicIndividualStatus = this.setRandomBasicIndividualStatus();
     this._basicTotalStatus = this.calculateBasicStatus();
+
+    this._remainingHp = this._basicTotalStatus.hp;
 
     this._moveList = this.getnitialMoveList();
   }

--- a/src/model/ExceptPokemon.ts
+++ b/src/model/ExceptPokemon.ts
@@ -1,0 +1,107 @@
+import { Pokemon } from "../model/pokemon/Pokemon";
+import { ILebel } from '../utils/interface/ILebel';
+import { IStatus } from '../utils/interface/IStatus';
+import { IMoveList } from '../utils/interface/IMoveList';
+import { TBasicStatus } from '../utils/type/TBasicStatus';
+import { Move } from '../model/move/Move';
+import { randomMultipleInArray } from '../utils/general';
+
+export class ExceptPokemon implements ILebel, IStatus,IMoveList {
+
+  /**
+   * ポケモン
+   */
+  protected readonly _pokemon: Pokemon;
+
+  /**
+   * おぼえているわざ
+   */
+  readonly _moveList: Move[];
+
+  /**
+   * レベル
+   */
+  readonly _lebel: number;
+
+  /**
+   * ステータス
+   */
+  _basicPokemonStatus: TBasicStatus;
+  _basicIndividualStatus: TBasicStatus;
+  _basicEffortStatus: TBasicStatus = {
+    hp: 0,
+    attack: 0,
+    protected: 0,
+    SPattack: 0,
+    SPprotected: 0,
+    rapidity: 0
+  };
+  _basicTotalStatus: TBasicStatus;
+
+  constructor(pokemon: Pokemon, lebel:number) {
+    this._pokemon = pokemon;
+    this._lebel = lebel;
+
+    this._basicPokemonStatus = this._pokemon.basicPokemonStatus;
+    this._basicIndividualStatus = this.setRandomBasicIndividualStatus();
+    this._basicTotalStatus = this.calculateBasicStatus();
+
+    this._moveList = this.getnitialMoveList();
+  }
+
+  /**
+   * ステータスの計算
+   */
+  calculateBasicStatus(): TBasicStatus {
+    const basicTotalStatus: TBasicStatus = {
+      hp: 0,
+      attack: 0,
+      protected: 0,
+      SPattack: 0,
+      SPprotected: 0,
+      rapidity: 0
+    };
+    for (let k of Object.keys(basicTotalStatus) as (keyof TBasicStatus)[]) {
+      const common = ((this._basicPokemonStatus[k] * 2) + this._basicIndividualStatus[k] + this._basicEffortStatus[k]) * this._lebel / 100;
+      basicTotalStatus[k] = k === 'hp' 
+        ? Math.round(common + this._lebel + 10)
+        : Math.round(common + 5)
+      ;
+    }
+    return basicTotalStatus;
+  }
+
+  /**
+   * 個体値をランダムでセットする
+   */
+  setRandomBasicIndividualStatus(): TBasicStatus {
+    const basicIndividualStatusTmp = {
+      hp: 0,
+      attack: 0,
+      protected: 0,
+      SPattack: 0,
+      SPprotected: 0,
+      rapidity: 0
+    }
+    for (let k of Object.keys(basicIndividualStatusTmp) as (keyof TBasicStatus)[]) {
+      basicIndividualStatusTmp[k] = Math.floor(Math.random() * 32);
+    }
+    return basicIndividualStatusTmp;
+  }
+
+  /**
+   * わざの取得
+   */
+  getnitialMoveList(): Move[] {
+    const moveListFromCurrentLebel: Move[] = this._pokemon.moveListToRequest
+      .filter(moveList => moveList.lebel <= this._lebel)
+      .map(moveList => moveList.move);
+    
+    if (moveListFromCurrentLebel.length > 4) {
+      return randomMultipleInArray<Move>(moveListFromCurrentLebel, 4);
+    } else {
+      return moveListFromCurrentLebel;
+    }
+  }
+  
+}

--- a/src/model/ExceptPokemon.ts
+++ b/src/model/ExceptPokemon.ts
@@ -6,7 +6,7 @@ import { TBasicStatus } from '../utils/type/TBasicStatus';
 import { Move } from '../model/move/Move';
 import { randomMultipleInArray } from '../utils/general';
 
-export class ExceptPokemon implements ILebel, IStatus,IMoveList {
+export class ExceptPokemon implements ILebel, IStatus, IMoveList {
 
   /**
    * ポケモン
@@ -38,7 +38,7 @@ export class ExceptPokemon implements ILebel, IStatus,IMoveList {
   };
   _basicTotalStatus: TBasicStatus;
 
-  constructor(pokemon: Pokemon, lebel:number) {
+  constructor(pokemon: Pokemon, lebel: number) {
     this._pokemon = pokemon;
     this._lebel = lebel;
 
@@ -47,6 +47,18 @@ export class ExceptPokemon implements ILebel, IStatus,IMoveList {
     this._basicTotalStatus = this.calculateBasicStatus();
 
     this._moveList = this.getnitialMoveList();
+  }
+
+  get name() {
+    return this._pokemon.name;
+  }
+
+  get lebel() {
+    return this._lebel;
+  }
+
+  get moveList() {
+    return this._moveList;
   }
 
   /**

--- a/src/model/OwnPokemon.ts
+++ b/src/model/OwnPokemon.ts
@@ -2,10 +2,13 @@ import { ExceptPokemon } from "../model/ExceptPokemon";
 import { ILebel } from '../utils/interface/ILebel';
 import { IStatus } from '../utils/interface/IStatus';
 import { IMoveList } from '../utils/interface/IMoveList';
+import { IPokemonBattle } from '../utils/interface/IPokemonBattle';
 import { TBasicStatus } from '../utils/type/TBasicStatus';
+import { TBattleStatusRank } from '../utils/type/TBattleStatusRank';
 import { Move } from '../model/move/Move';
+import { StatusAilment } from '../model/statusAilment/StatusAilment';
 
-export class OwnPokemon　implements ILebel, IStatus, IMoveList {
+export class OwnPokemon　implements ILebel, IStatus, IMoveList, IPokemonBattle {
   /**
    * ポケモン
    */
@@ -44,19 +47,36 @@ export class OwnPokemon　implements ILebel, IStatus, IMoveList {
   _basicEffortStatus: TBasicStatus;
   _basicTotalStatus: TBasicStatus;
 
+  /**
+   * 残りHP
+   */
+  _remainingHp: number;
+
+  /**
+   * 状態異常
+   */
+  _statusAilment: StatusAilment[];
+
+  /**
+   * バトルステータスランク
+   */
+  _battleStatusRank: TBattleStatusRank;
+
   constructor(pokemon: ExceptPokemon, encounterField: Field.name, nickname?: string) {
     this._nickname = nickname ?? pokemon.name;
-    this._pokemon = pokemon;
     this._encounter = encounterField;
 
-    /** ステータス等の引き継ぎ */
-    this._lebel = this._pokemon.lebel;
-    this._basicPokemonStatus = this._pokemon._basicPokemonStatus;
-    this._basicIndividualStatus = this._pokemon._basicIndividualStatus;
-    this._basicEffortStatus = this._pokemon._basicEffortStatus;
+    /** ステータス等をExceptPokemonクラスから引き継ぎ */
+    this._pokemon = pokemon;
+    this._lebel = pokemon.lebel;
+    this._basicPokemonStatus = pokemon._basicPokemonStatus;
+    this._basicIndividualStatus = pokemon._basicIndividualStatus;
+    this._basicEffortStatus = pokemon._basicEffortStatus;
     this._basicTotalStatus = this.calculateBasicStatus();
-    this._moveList = this._pokemon.moveList;
-
+    this._moveList = pokemon._moveList;
+    this._remainingHp = pokemon._remainingHp;
+    this._statusAilment = pokemon._statusAilment;
+    this._battleStatusRank = pokemon._battleStatusRank;
     this._exPoint = Math.pow(this._lebel, 3);
   }
 

--- a/src/model/OwnPokemon.ts
+++ b/src/model/OwnPokemon.ts
@@ -1,0 +1,24 @@
+import { Pokemon } from "../__old/classes/Pokemon";
+
+export class OwnPokemon {
+  /**
+   * ポケモン
+   */
+  _pokemon: ExceptPokemon;
+
+  /**
+   * ニックネーム
+   */
+  _nickname: string;
+
+  /**
+   * もっているわざ
+   */
+  _moveList: Move[];
+
+  constructor(pokemon: ExceptPokemon, nickname?: string) {
+    this._nickname = nickname ?? Pokemon.name;
+    this._pokemon = pokemon;
+    this._pokemon = pokemon.moveList;
+  }
+}

--- a/src/model/OwnPokemon.ts
+++ b/src/model/OwnPokemon.ts
@@ -1,10 +1,15 @@
-import { Pokemon } from "../__old/classes/Pokemon";
+import { ExceptPokemon } from "../model/ExceptPokemon";
+import { ILebel } from '../utils/interface/ILebel';
+import { IStatus } from '../utils/interface/IStatus';
+import { IMoveList } from '../utils/interface/IMoveList';
+import { TBasicStatus } from '../utils/type/TBasicStatus';
+import { Move } from '../model/move/Move';
 
-export class OwnPokemon {
+export class OwnPokemon　implements ILebel, IStatus, IMoveList {
   /**
    * ポケモン
    */
-  _pokemon: ExceptPokemon;
+  protected _pokemon: ExceptPokemon;
 
   /**
    * ニックネーム
@@ -12,13 +17,79 @@ export class OwnPokemon {
   _nickname: string;
 
   /**
-   * もっているわざ
+   * おぼえているわざ
    */
   _moveList: Move[];
 
-  constructor(pokemon: ExceptPokemon, nickname?: string) {
-    this._nickname = nickname ?? Pokemon.name;
+  /**
+   * レベル
+   */
+  _lebel: number;
+
+  /**
+   * 経験値
+   */
+  _exPoint: number;
+
+  /**
+   * 出会った場所
+   */
+  _encounter: Field.name;
+   
+  /**
+   * ステータス
+   */
+  _basicPokemonStatus: TBasicStatus;
+  _basicIndividualStatus: TBasicStatus;
+  _basicEffortStatus: TBasicStatus;
+  _basicTotalStatus: TBasicStatus;
+
+  constructor(pokemon: ExceptPokemon, encounterField: Field.name, nickname?: string) {
+    this._nickname = nickname ?? pokemon.name;
     this._pokemon = pokemon;
-    this._pokemon = pokemon.moveList;
+    this._encounter = encounterField;
+
+    /** ステータス等の引き継ぎ */
+    this._lebel = this._pokemon.lebel;
+    this._basicPokemonStatus = this._pokemon._basicPokemonStatus;
+    this._basicIndividualStatus = this._pokemon._basicIndividualStatus;
+    this._basicEffortStatus = this._pokemon._basicEffortStatus;
+    this._basicTotalStatus = this.calculateBasicStatus();
+    this._moveList = this._pokemon.moveList;
+
+    this._exPoint = Math.pow(this._lebel, 3);
   }
+
+  /**
+   * ステータスの計算
+   */
+  calculateBasicStatus(): TBasicStatus {
+    const basicTotalStatus: TBasicStatus = {
+      hp: 0,
+      attack: 0,
+      protected: 0,
+      SPattack: 0,
+      SPprotected: 0,
+      rapidity: 0
+    };
+    for (let k of Object.keys(basicTotalStatus) as (keyof TBasicStatus)[]) {
+      const common = ((this._basicPokemonStatus[k] * 2) + this._basicIndividualStatus[k] + this._basicEffortStatus[k]) * this._lebel / 100;
+      basicTotalStatus[k] = k === 'hp' 
+        ? Math.round(common + this._lebel + 10)
+        : Math.round(common + 5)
+      ;
+    }
+    return basicTotalStatus;
+  }
+
+  /**
+   * 次のレベルまでに必要な経験値を取得
+   */
+  getReqLebelUpExPoint(): number {
+    if (this._lebel >= 100) {
+      return 0;
+    }
+    return (Math.pow(this._lebel + 1, 3)) - this._exPoint;
+  }
+  
 }

--- a/src/model/classdata/groupClassDatas.ts
+++ b/src/model/classdata/groupClassDatas.ts
@@ -1,0 +1,36 @@
+import { Denki } from '../group/Denki';
+import { Mizu } from '../group/Mizu';
+import { Kusa } from '../group/Kusa';
+import { Honoo } from '../group/Honoo';
+import { Jimen } from '../group/Jimen';
+import { Kakutou } from '../group/Kakutou';
+import { Normal } from '../group/Normal';
+import { Goast } from '../group/Goast';
+import { Group } from '../group/Group';
+
+export type GROUP_KEYTYPE = 'denki' | 'hagane' | 'hikou' | 'koori' | 'kakutou' | 'mizu'
+                            | 'kusa' | 'doku' | 'jimen' | 'mushi' | 'iwa' | 'dragon'
+                            | 'aku' | 'goast' | 'esper' | 'faily' | 'normal' | 'honoo';
+
+export const GROUP_CLASS_LIST: {
+  [key: string]: Group;
+} = {
+  "denki": new Denki(),
+  "hagane": new Denki(),
+  "hikou": new Denki(),
+  "koori": new Denki(),
+  "kakutou": new Kakutou(),
+  "mizu": new Mizu(),
+  "kusa": new Kusa(),
+  "doku": new Denki(),
+  "jimen": new Jimen(),
+  "mushi": new Denki(),
+  "iwa": new Denki(),
+  "dragon": new Denki(),
+  "aku": new Denki(),
+  "goast": new Goast(),
+  "esper": new Denki(),
+  "faily": new Denki(),
+  "normal": new Normal(),
+  "honoo": new Honoo(),
+}

--- a/src/model/classdata/moveClassDatas.ts
+++ b/src/model/classdata/moveClassDatas.ts
@@ -1,0 +1,82 @@
+import { DenkiShock } from '../move/DenkiShock';
+import { Nakigoe } from '../move/Nakigoe';
+import { Niramitsukeru } from '../move/Niramitsukeru';
+import { Taiatari } from '../move/Taiatari';
+import { Hataku } from '../move/Hataku';
+import { Hikkaku } from '../move/Hikkaku';
+import { Konoha } from '../move/Konoha';
+import { Hinoko } from '../move/Hinoko';
+import { MizuDeppou } from '../move/MizuDeppou';
+import { Denjiha } from '../move/Denjiha';
+import { Move } from '../move//Move';
+
+export const MOVE_CLASS_LIST: {
+  [key: string]: Move;
+} = {
+  "denkiShock": new DenkiShock(),
+  "nakigoe": new Nakigoe(),
+  "hikkaku": new Hikkaku(),
+  "jumanBoruto": new Nakigoe(),
+  "shippoWoFuru": new Nakigoe(),
+  "kaminari": new Nakigoe(),
+  "denkouSekka": new Nakigoe(),
+  "aianTeru": new Nakigoe(),
+  "taiatari": new Taiatari(),
+  "denjiha": new Denjiha(),
+  "speedStar": new Nakigoe(),
+  "yadorigiNoTane": new Nakigoe(),
+  "tsuruNoMuchi": new Nakigoe(),
+  "dokuNoKona": new Nakigoe(),
+  "happaCutter": new Nakigoe(),
+  "seichou": new Nakigoe(),
+  "nemurigona": new Nakigoe(),
+  "solarBeam": new Nakigoe(),
+  "mizudeppou": new MizuDeppou(),
+  "iwakudaki": new Nakigoe(),
+  "iwaotoshi": new Nakigoe(),
+  "mamoru": new Nakigoe(),
+  "choonpa": new Nakigoe(),
+  "mizuNoHadou": new Nakigoe(),
+  "iwanadare": new Nakigoe(),
+  "tosshin": new Nakigoe(),
+  "dowasure": new Nakigoe(),
+  "narminori": new Nakigoe(),
+  "iyaNaOto": new Nakigoe(),
+  "gamusyara": new Nakigoe(),
+  "hydroPump": new Nakigoe(),
+  "madShot": new Nakigoe(),
+  "armHammer": new Nakigoe(),
+  "jishin": new Nakigoe(),
+  "hataku": new Hataku(),
+  "niramitsukeru": new Niramitsukeru(),
+  "mikiri": new Nakigoe(),
+  "konoha": new Konoha(),
+  "gigadorain": new Nakigoe(),
+  "megadorain": new Nakigoe(),
+  "fastGuard": new Nakigoe(),
+  "dameoshi": new Nakigoe(),
+  "tatakitsukeru": new Nakigoe(),
+  "kagebunshin": new Nakigoe(),
+  "leafStorm": new Nakigoe(),
+  "enegyBall": new Nakigoe(),
+  "renzokugiri": new Nakigoe(),
+  "mineuchi": new Nakigoe(),
+  "scissorCross": new Nakigoe(),
+  "leafblade": new Nakigoe(),
+  "doubleChop": new Nakigoe(),
+  "nitroCharge": new Nakigoe(),
+  "hinoko": new Hinoko(),
+  "kaenhousya": new Nakigoe(),
+  "sunakake": new Nakigoe(),
+  "tsubamegaeshi": new Nakigoe(),
+  "kirisaku": new Nakigoe(),
+  "kiaidame": new Nakigoe(),
+  "tobihaneru": new Nakigoe(),
+  "featherDance": new Nakigoe(),
+  "kishikaisei": new Nakigoe(),
+  "flareDrive": new Nakigoe(),
+  "nidogeri": new Nakigoe(),
+  "blazeKick": new Nakigoe(),
+  "honooNoPunchi": new Nakigoe(),
+  "buildUp": new Nakigoe(),
+}

--- a/src/model/classdata/statusAilmentDatas.ts
+++ b/src/model/classdata/statusAilmentDatas.ts
@@ -1,0 +1,20 @@
+import { StatusAilment } from '../statusAilment/StatusAilment';
+import { SaParalysis } from '../statusAilment/SaParalysis';
+import { SaBadPoison } from '../statusAilment/SaBadPoison';
+import { SaPoison } from '../statusAilment/SaPoison';
+import { SaFreeze } from '../statusAilment/SaFreeze';
+import { SaSleep } from '../statusAilment/SaSleep';
+import { SaBurn } from '../statusAilment/SaBurn';
+import { SaFainting } from '../statusAilment/SaFainting';
+
+export const STATUS_AILMENT_CLASS_LIST: {
+  [key: string]: StatusAilment;
+} = {
+  'saBurn': new SaBurn(),
+  'saFreeze': new SaFreeze(),
+  'saParalysis': new SaParalysis(),
+  'saPoison': new SaPoison(),
+  'saBadPoison': new SaBadPoison(),
+  'saSleep': new SaSleep(),
+  'saFainting': new SaFainting()
+}

--- a/src/model/group/Denki.ts
+++ b/src/model/group/Denki.ts
@@ -1,0 +1,11 @@
+import { Group } from './Group';
+import { GROUP_KEYTYPE } from '../classdata/groupClassDatas';
+
+export class Denki extends Group {
+  
+  _name = 'でんき';
+  _keyType: GROUP_KEYTYPE = 'denki';
+  _excellent: GROUP_KEYTYPE[] = ['mizu', 'hikou'];
+  _notVery: GROUP_KEYTYPE[] = ['denki', 'kusa', 'dragon'];
+  _doesntAffext: GROUP_KEYTYPE[] = ['jimen'];
+}

--- a/src/model/group/Goast.ts
+++ b/src/model/group/Goast.ts
@@ -1,0 +1,11 @@
+import { Group } from './Group';
+import { GROUP_KEYTYPE } from '../classdata/groupClassDatas';
+
+export class Goast extends Group {
+  
+  _name = 'ゴースト';
+  _keyType: GROUP_KEYTYPE = 'goast';
+  _excellent: GROUP_KEYTYPE[] = ['esper', 'goast'];
+  _notVery: GROUP_KEYTYPE[] = ['aku'];
+  _doesntAffext: GROUP_KEYTYPE[] = ['normal'];
+}

--- a/src/model/group/Group.ts
+++ b/src/model/group/Group.ts
@@ -1,0 +1,51 @@
+import { GROUP_KEYTYPE } from '../classdata/groupClassDatas';
+
+export abstract class Group {
+
+  /**
+   * 正式名称
+   */
+   protected abstract _name: string;
+
+
+  /**
+   * キータイプ
+   */
+  protected abstract _keyType: GROUP_KEYTYPE;
+
+  /**
+   * 攻撃：こうかばつぐん
+   */
+  protected abstract _excellent: GROUP_KEYTYPE[];
+
+  /**
+   * 攻撃：こうかいまひとつ
+   */
+  protected abstract _notVery: GROUP_KEYTYPE[];
+
+  /**
+   * 攻撃：こうかがない
+   */
+  protected abstract _doesntAffext: GROUP_KEYTYPE[];
+
+  get name() {
+    return this._name;
+  }
+
+  get keyType() {
+    return this._keyType;
+  }
+
+  get excellent() {
+    return this._excellent;
+  }
+
+  get notVery() {
+    return this._notVery;
+  }
+  
+  get doesntAffext() {
+    return this._doesntAffext;
+  }
+
+}

--- a/src/model/group/Honoo.ts
+++ b/src/model/group/Honoo.ts
@@ -1,0 +1,11 @@
+import { Group } from './Group';
+import { GROUP_KEYTYPE } from '../classdata/groupClassDatas';
+
+export class Honoo extends Group {
+  
+  _name = 'ほのお';
+  _keyType: GROUP_KEYTYPE = 'honoo';
+  _excellent: GROUP_KEYTYPE[] = ['kusa', 'koori', 'mushi', 'hagane'];
+  _notVery: GROUP_KEYTYPE[] = ['honoo', 'mizu', 'iwa', 'dragon'];
+  _doesntAffext: GROUP_KEYTYPE[] = [];
+}

--- a/src/model/group/Jimen.ts
+++ b/src/model/group/Jimen.ts
@@ -1,0 +1,11 @@
+import { Group } from './Group';
+import { GROUP_KEYTYPE } from '../classdata/groupClassDatas';
+
+export class Jimen extends Group {
+  
+  _name = 'じめん';
+  _keyType: GROUP_KEYTYPE = 'jimen';
+  _excellent: GROUP_KEYTYPE[] = ['honoo', 'denki', 'doku', 'iwa', 'hagane'];
+  _notVery: GROUP_KEYTYPE[] = ['kusa', 'mushi'];
+  _doesntAffext: GROUP_KEYTYPE[] = ['denki'];
+}

--- a/src/model/group/Kakutou.ts
+++ b/src/model/group/Kakutou.ts
@@ -1,0 +1,12 @@
+import { Group } from './Group';
+import { GROUP_KEYTYPE } from '../classdata/groupClassDatas';
+
+export class Kakutou extends Group {
+  
+  _name = 'かくとう';
+  _keyType: GROUP_KEYTYPE = 'kakutou';
+  _excellent: GROUP_KEYTYPE[] = ['normal', 'koori', 'aku', 'iwa', 'hagane'];
+  _notVery: GROUP_KEYTYPE[] = ['doku', 'hikou', 'esper', 'faily', 'mushi'];
+  _doesntAffext: GROUP_KEYTYPE[] = ['goast'];
+  
+}

--- a/src/model/group/Kusa.ts
+++ b/src/model/group/Kusa.ts
@@ -1,0 +1,11 @@
+import { Group } from './Group';
+import { GROUP_KEYTYPE } from '../classdata/groupClassDatas';
+
+export class Kusa extends Group {
+  
+  _name = 'くさ';
+  _keyType: GROUP_KEYTYPE = 'kusa';
+  _excellent: GROUP_KEYTYPE[] = ['mizu', 'jimen', 'iwa'];
+  _notVery: GROUP_KEYTYPE[] = ['kusa', 'honoo', 'doku', 'hikou', 'mushi', 'hagane', 'dragon'];
+  _doesntAffext: GROUP_KEYTYPE[] = [];
+}

--- a/src/model/group/Mizu.ts
+++ b/src/model/group/Mizu.ts
@@ -1,0 +1,11 @@
+import { Group } from './Group';
+import { GROUP_KEYTYPE } from '../classdata/groupClassDatas';
+
+export class Mizu extends Group {
+  
+  _name = 'みず';
+  _keyType: GROUP_KEYTYPE = 'mizu';
+  _excellent: GROUP_KEYTYPE[] = ['honoo', 'jimen', 'iwa'];
+  _notVery: GROUP_KEYTYPE[] = ['kusa', 'mizu', 'dragon'];
+  _doesntAffext: GROUP_KEYTYPE[] = [];
+}

--- a/src/model/group/Normal.ts
+++ b/src/model/group/Normal.ts
@@ -1,0 +1,11 @@
+import { Group } from './Group';
+import { GROUP_KEYTYPE } from '../classdata/groupClassDatas';
+
+export class Normal extends Group {
+  
+  _name = 'ノーマル';
+  _keyType: GROUP_KEYTYPE = 'normal';
+  _excellent: GROUP_KEYTYPE[] = [];
+  _notVery: GROUP_KEYTYPE[] = ['iwa', 'hagane'];
+  _doesntAffext: GROUP_KEYTYPE[] = ['goast'];
+}

--- a/src/model/move/Denjiha.ts
+++ b/src/model/move/Denjiha.ts
@@ -1,0 +1,61 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class Denjiha extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'でんじは';
+
+  /**
+   * 説明
+   */
+  _description = '相手をまひ状態にする';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '変化';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.denki;
+
+  /**
+   * 威力
+   */
+  _power = null;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 90;
+
+  /**
+   * PP
+   */
+  _pp = 20;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+
+  effects(...pokemons: Pokemon[]): string {
+
+    const [atkPokemon, defPokemon] = pokemons;
+    const resultMessage: string = defPokemon.setStatusAilment(STATUS_AILMENT_CLASS_LIST.saParalysis);
+    return resultMessage;
+
+  }
+}

--- a/src/model/move/DenkiShock.ts
+++ b/src/model/move/DenkiShock.ts
@@ -1,0 +1,53 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class DenkiShock extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'でんきショック';
+
+  /**
+   * 説明
+   */
+  _description = '10%のかくりつで相手をまひさせる。';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '特殊';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.denki;
+
+  /**
+   * 威力
+   */
+  _power = 40;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 100;
+
+  /**
+   * PP
+   */
+  _pp = 40;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+}

--- a/src/model/move/Hataku.ts
+++ b/src/model/move/Hataku.ts
@@ -1,0 +1,53 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class Hataku extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'はたく';
+
+  /**
+   * 説明
+   */
+  _description = '長いしっぽや手などを使って相手をはたいて攻撃する';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '物理';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.normal;
+
+  /**
+   * 威力
+   */
+  _power = 40;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 100;
+
+  /**
+   * PP
+   */
+  _pp = 35;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+}

--- a/src/model/move/Hikkaku.ts
+++ b/src/model/move/Hikkaku.ts
@@ -1,0 +1,53 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class Hikkaku extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'ひっかく';
+
+  /**
+   * 説明
+   */
+  _description = '硬くとがった鋭いツメで相手をひっかいて攻撃する';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '物理';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.normal;
+
+  /**
+   * 威力
+   */
+  _power = 40;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 100;
+
+  /**
+   * PP
+   */
+  _pp = 35;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+  
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+}

--- a/src/model/move/Hinoko.ts
+++ b/src/model/move/Hinoko.ts
@@ -1,0 +1,53 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class Hinoko extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'ひのこ';
+
+  /**
+   * 説明
+   */
+  _description = '小さな炎を相手に発射して攻撃する。やけど状態にすることがある';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '特殊';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.honoo;
+
+  /**
+   * 威力
+   */
+  _power = 40;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 100;
+
+  /**
+   * PP
+   */
+  _pp = 25;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+}

--- a/src/model/move/Konoha.ts
+++ b/src/model/move/Konoha.ts
@@ -1,0 +1,53 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class Konoha extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'このは';
+
+  /**
+   * 説明
+   */
+  _description = 'はっぱを相手に当てて攻撃する';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '物理';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.kusa;
+
+  /**
+   * 威力
+   */
+  _power = 40;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 100;
+
+  /**
+   * PP
+   */
+  _pp = 40;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+}

--- a/src/model/move/MizuDeppou.ts
+++ b/src/model/move/MizuDeppou.ts
@@ -1,0 +1,53 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class MizuDeppou extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'みずでっぽう';
+
+  /**
+   * 説明
+   */
+  _description = '水を勢いよく相手に発射して攻撃する';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '特殊';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.mizu;
+
+  /**
+   * 威力
+   */
+  _power = 40;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 100;
+
+  /**
+   * PP
+   */
+  _pp = 25;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+  
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+}

--- a/src/model/move/Move.ts
+++ b/src/model/move/Move.ts
@@ -1,0 +1,95 @@
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+
+export abstract class Move {
+
+  /**
+   * 名前
+   */
+  abstract _name: string;
+
+  /**
+   * 説明
+   */
+  abstract _description: string;
+
+  /**
+   * わざ種別
+   */
+  abstract _species: '物理' | '特殊' | '変化';
+
+  /**
+   * わざタイプ
+   */
+  abstract _type: Group;
+
+  /**
+   * 威力
+   */
+  abstract _power: number | null;
+
+  /**
+   * 命中率
+   */
+  abstract _accuracy: number;
+
+  /**
+   * PP
+   */
+  abstract _pp: number;
+
+  /**
+   * 優先度
+   */
+  abstract _priority: number;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  abstract _criticalRank: number | null;
+
+  /**
+   * 追加効果
+   */
+  effects(...pokemons: Pokemon[]): string {
+    return '';
+  }
+
+
+  get name() {
+    return this._name;
+  }
+  
+  get description() {
+    return this._description;
+  }
+  
+  get species() {
+    return this._species;
+  }
+
+  get type() {
+    return this._type;
+  }
+
+  get power() {
+    return this._power;
+  }
+
+  get accuracy() {
+    return this._accuracy;
+  }
+
+  get pp() {
+    return this._pp;
+  }
+  
+  get priority() {
+    return this._priority;
+  }
+
+  get criticalRank() {
+    return this._criticalRank;
+  }
+
+}

--- a/src/model/move/Nakigoe.ts
+++ b/src/model/move/Nakigoe.ts
@@ -1,0 +1,61 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class Nakigoe extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'なきごえ';
+
+  /**
+   * 説明
+   */
+  _description = '相手のこうげきを一段下げる';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '変化';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.normal;
+
+  /**
+   * 威力
+   */
+  _power = null;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 100;
+
+  /**
+   * PP
+   */
+  _pp = 40;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+
+  effects(...pokemons: Pokemon[]): string {
+
+    const [atkPokemon, defPokemon] = pokemons;
+    const resultMessage: string = defPokemon.subBattleStatusRank('attack', 1);
+    return resultMessage;
+
+  }
+}

--- a/src/model/move/Niramitsukeru.ts
+++ b/src/model/move/Niramitsukeru.ts
@@ -1,0 +1,61 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class Niramitsukeru extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'にらみつける';
+
+  /**
+   * 説明
+   */
+  _description = '相手のぼうぎょを一段下げる';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '変化';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.normal;
+
+  /**
+   * 威力
+   */
+  _power = null;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 100;
+
+  /**
+   * PP
+   */
+  _pp = 30;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+
+  effects(...pokemons: Pokemon[]): string {
+
+    const [atkPokemon, defPokemon] = pokemons;
+    const resultMessage: string = defPokemon.subBattleStatusRank('protected', 1);
+    return resultMessage;
+
+  }
+}

--- a/src/model/move/Taiatari.ts
+++ b/src/model/move/Taiatari.ts
@@ -1,0 +1,53 @@
+import { Move } from './Move';
+import { Group } from '../group/Group';
+import { Pokemon } from '../pokemon/Pokemon';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { STATUS_AILMENT_CLASS_LIST } from '../classdata/statusAilmentDatas';
+
+export class Taiatari extends Move {
+
+  /**
+   * 名前
+   */
+  _name = 'たいあたり';
+
+  /**
+   * 説明
+   */
+  _description = '相手にむかって全身でぶつかっていき攻撃する';
+
+  /**
+   * わざ種別
+   */
+  _species: '物理' | '特殊' | '変化' = '物理';
+
+  /**
+   * わざタイプ
+   */
+  _type: Group = GROUP_CLASS_LIST.normal;
+
+  /**
+   * 威力
+   */
+  _power = 40;
+
+  /**
+   * 命中率
+   */
+  _accuracy = 100;
+
+  /**
+   * PP
+   */
+  _pp = 35;
+
+  /**
+   * 優先度
+   */
+  _priority = 0;
+
+  /**
+   * 急所に当たりやすいランク
+   */
+  _criticalRank = 0;
+}

--- a/src/model/pokemon/Achamo.ts
+++ b/src/model/pokemon/Achamo.ts
@@ -1,0 +1,47 @@
+import { Pokemon } from './Pokemon';
+import { Group } from '../group/Group';
+import { Move } from '../move/Move';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { MOVE_CLASS_LIST } from '../classdata/moveClassDatas';
+
+export class Achamo extends Pokemon {
+
+  /**
+   * ポケモン名称
+   */
+  protected readonly _name: string = 'アチャモ';
+
+  /**
+   * ポケモン種別（●●ポケモン）
+   */
+  protected readonly _pokemonType: string = 'ひよこポケモン';
+
+  /**
+   * タイプ
+   */
+  protected readonly _groups: Group[] = [ GROUP_CLASS_LIST.honoo ];
+
+  /**
+   * おぼえられるわざ一覧
+   */
+  protected readonly _moveListToRequest: {
+    lebel: number;
+    move: Move
+  }[] = [
+    {lebel: 1, move: MOVE_CLASS_LIST.hikkaku},
+    {lebel:1, move: MOVE_CLASS_LIST.nakigoe},
+    {lebel:3, move: MOVE_CLASS_LIST.hinoko},
+    // {lebel:6, move: 'でんこうせっか'},
+    // {lebel:9, move: 'ニトロチャージ'},
+    // {lebel:12, move: 'みきり'},
+    // {lebel:15, move: 'すなかけ'},
+    // {lebel:18, move: 'つばめがえし'},
+    // {lebel:21, move: 'きりさく'},
+    // {lebel:24, move: 'とびはねる'},
+    // {lebel:27, move: 'きあいだめ'},
+    // {lebel:30, move: 'かえんほうしゃ'},
+    // {lebel:33, move: 'フェザーダンス'},
+    // {lebel:36, move: 'きしかいせい'},
+    // {lebel:39, move: 'フレアドライブ'}
+  ];
+}

--- a/src/model/pokemon/Kimori.ts
+++ b/src/model/pokemon/Kimori.ts
@@ -1,0 +1,47 @@
+import { Pokemon } from './Pokemon';
+import { Group } from '../group/Group';
+import { Move } from '../move/Move';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { MOVE_CLASS_LIST } from '../classdata/moveClassDatas';
+
+export class Kimori extends Pokemon {
+
+  /**
+   * ポケモン名称
+   */
+  protected readonly _name: string = 'キモリ';
+
+  /**
+   * ポケモン種別（●●ポケモン）
+   */
+  protected readonly _pokemonType: string = 'もりトカゲポケモン';
+
+  /**
+   * タイプ
+   */
+  protected readonly _groups: Group[] = [ GROUP_CLASS_LIST.kusa ];
+
+  /**
+   * おぼえられるわざ一覧
+   */
+  protected readonly _moveListToRequest: {
+    lebel: number;
+    move: Move
+  }[] = [
+    {lebel: 1, move: MOVE_CLASS_LIST.hataku},
+    {lebel:1, move: MOVE_CLASS_LIST.niramitsukeru},
+    {lebel:3, move: MOVE_CLASS_LIST.konoha},
+    // {lebel:6, move: 'でんこうせっか'},
+    // {lebel:9, move: 'メガドレイン'},
+    // {lebel:12, move: 'みきり'},
+    // {lebel:15, move: 'ファストガード'},
+    // {lebel:18, move: 'だめおし'},
+    // {lebel:21, move: 'ギガドレイン'},
+    // {lebel:24, move: 'たたきつける'},
+    // {lebel:27, move: 'かげぶんしん'},
+    // {lebel:30, move: 'エナジーボール'},
+    // {lebel:33, move: 'いやなおと'},
+    // {lebel:36, move: 'がむしゃら'},
+    // {lebel:39, move: 'リーフストーム'}
+  ];
+}

--- a/src/model/pokemon/Mizugorou.ts
+++ b/src/model/pokemon/Mizugorou.ts
@@ -1,0 +1,48 @@
+import { Pokemon } from './Pokemon';
+import { Group } from '../group/Group';
+import { Move } from '../move/Move';
+import { GROUP_CLASS_LIST } from '../classdata/groupClassDatas';
+import { MOVE_CLASS_LIST } from '../classdata/moveClassDatas';
+
+export class Mizugorou extends Pokemon {
+
+  /**
+   * ポケモン名称
+   */
+  protected readonly _name: string = 'ミズゴロウ';
+
+  /**
+   * ポケモン種別（●●ポケモン）
+   */
+  protected readonly _pokemonType: string = 'ぬまうおポケモン';
+
+  /**
+   * タイプ
+   */
+  protected readonly _groups: Group[] = [ GROUP_CLASS_LIST.mizu ];
+
+  /**
+   * おぼえられるわざ一覧
+   */
+  protected readonly _moveListToRequest: {
+    lebel: number;
+    move: Move
+  }[] = [
+    {lebel: 1, move: MOVE_CLASS_LIST.taiatari},
+    {lebel:1, move: MOVE_CLASS_LIST.nakigoe},
+    {lebel:3, move: MOVE_CLASS_LIST.mizudeppou},
+    {lebel:3, move: MOVE_CLASS_LIST.denjiha}
+    // {lebel:6, move: 'いわくだき'},
+    // {lebel:9, move: 'いわおとし'},
+    // {lebel:12, move: 'まもる'},
+    // {lebel:15, move: 'ちょうおんぱ'},
+    // {lebel:18, move: 'みずのはどう'},
+    // {lebel:21, move: 'いわなだれ'},
+    // {lebel:24, move: 'とっしん'},
+    // {lebel:27, move: 'ドわすれ'},
+    // {lebel:30, move: 'なみのり'},
+    // {lebel:33, move: 'いやなおと'},
+    // {lebel:36, move: 'がむしゃら'},
+    // {lebel:39, move: 'ハイドロポンプ'}
+  ];
+}

--- a/src/model/pokemon/Pokemon.ts
+++ b/src/model/pokemon/Pokemon.ts
@@ -1,4 +1,4 @@
-import { IBasicStatus } from "../../utils/interfaces/IbasicStatus";
+import { TBasicStatus } from "../../utils/type/TBasicStatus";
 
 export abstract class Pokemon {
 
@@ -18,29 +18,58 @@ export abstract class Pokemon {
   protected readonly abstract _groups: Group[];
 
   /**
+   * おぼえられるわざ一覧
+   */
+  protected readonly abstract _moveListToRequest: {
+    lebel: number;
+    move: Move
+  }
+
+  /**
    * 種族値
    */
-  protected readonly abstract _basicPokemonStatus: IBasicStatus;
+  protected readonly abstract _basicPokemonStatus: TBasicStatus;
 
   /**
    * 個体値
    */
-  protected abstract _basicIndividualStatus: IBasicStatus;
+  protected abstract _basicIndividualStatus: TBasicStatus = {
+    hp: 0,
+    attack: 0,
+    protected: 0,
+    SPattack: 0,
+    SPprotected: 0,
+    rapidity: 0
+  }
 
   /**
    * 努力値
    */
-  protected abstract _basicEffortStatus: IBasicStatus;
+  protected abstract _basicEffortStatus: TBasicStatus = {
+    hp: 0,
+    attack: 0,
+    protected: 0,
+    SPattack: 0,
+    SPprotected: 0,
+    rapidity: 0
+  }
 
-  /**
-   * 種族値・個体値・努力値を合わせた決定ステータス
-   */
-  protected abstract _basicTotalStatus: IBasicStatus;
+  /* レベル・わざ・ステータスは、ExceptPokemonとOwnPokemonのインスタンス生成時に必ず
 
   /**
    * レベル
    */
-  protected abstract _lebel: number;
+  protected abstract _lebel: number = 0;
+
+  /**
+   * おぼえているわざ
+   */
+  protected readonly abstract _moveList: Move[] = [];
+  
+  /**
+   * 種族値・個体値・努力値を合わせた決定ステータス
+   */
+  protected abstract _basicTotalStatus: TBasicStatus;
 
   /**
    * ゲッター・セッター
@@ -96,8 +125,8 @@ export abstract class Pokemon {
    * @param _basicIndividualStatus 個体値
    * @param _basicEffortStatus 努力値
    */
-  calculateBasicStatus(_basicPokemonStatus: IBasicStatus, _basicIndividualStatus: IBasicStatus, _basicEffortStatus: IBasicStatus): void {
-    for (let k of Object.keys(this._basicTotalStatus) as (keyof IBasicStatus)[]) {
+  calculateBasicStatus(_basicPokemonStatus: TBasicStatus, _basicIndividualStatus: TBasicStatus, _basicEffortStatus: TBasicStatus): void {
+    for (let k of Object.keys(this._basicTotalStatus) as (keyof TBasicStatus)[]) {
       const common = ((_basicPokemonStatus[k] * 2) + _basicIndividualStatus[k] + _basicEffortStatus[k]) * this._lebel / 100;
       this._basicTotalStatus[k] = k === 'hp' 
         ? Math.round(common + this._lebel + 10)

--- a/src/model/pokemon/Pokemon.ts
+++ b/src/model/pokemon/Pokemon.ts
@@ -25,7 +25,7 @@ export abstract class Pokemon {
   protected readonly abstract _moveListToRequest: {
     lebel: number;
     move: Move
-  }
+  }[];
 
   /**
    * 種族値
@@ -118,6 +118,10 @@ export abstract class Pokemon {
 
   get groups() {
     return this._groups;
+  }
+
+  get moveListToRequest() {
+    return this._moveListToRequest;
   }
 
 

--- a/src/model/pokemon/Pokemon.ts
+++ b/src/model/pokemon/Pokemon.ts
@@ -1,4 +1,5 @@
 import { TBasicStatus } from "../../utils/type/TBasicStatus";
+import { Group } from '../group/Group';
 
 export abstract class Pokemon {
 

--- a/src/model/pokemon/Pokemon.ts
+++ b/src/model/pokemon/Pokemon.ts
@@ -1,5 +1,6 @@
 import { TBasicStatus } from "../../utils/type/TBasicStatus";
 import { Group } from '../group/Group';
+import { Move } from '../move/Move';
 
 export abstract class Pokemon {
 

--- a/src/model/pokemon/Pokemon.ts
+++ b/src/model/pokemon/Pokemon.ts
@@ -1,0 +1,108 @@
+import { IBasicStatus } from "../../utils/interfaces/IbasicStatus";
+
+export abstract class Pokemon {
+
+  /**
+   * ポケモン名称
+   */
+  protected readonly abstract _name: string;
+
+  /**
+   * ポケモン種別（●●ポケモン）
+   */
+  protected readonly abstract _pokemonType: string;
+
+  /**
+   * タイプ
+   */
+  protected readonly abstract _groups: Group[];
+
+  /**
+   * 種族値
+   */
+  protected readonly abstract _basicPokemonStatus: IBasicStatus;
+
+  /**
+   * 個体値
+   */
+  protected abstract _basicIndividualStatus: IBasicStatus;
+
+  /**
+   * 努力値
+   */
+  protected abstract _basicEffortStatus: IBasicStatus;
+
+  /**
+   * 種族値・個体値・努力値を合わせた決定ステータス
+   */
+  protected abstract _basicTotalStatus: IBasicStatus;
+
+  /**
+   * レベル
+   */
+  protected abstract _lebel: number;
+
+  /**
+   * ゲッター・セッター
+   */
+  get name() {
+    return this._name;
+  }
+
+  get lebel() {
+    return this._lebel;
+  }
+
+  set lebel(lebel) {
+    this._lebel = lebel;
+  }
+
+  get basicPokemonStatus() {
+    return this._basicPokemonStatus;
+  }
+
+  get basicEffortStatus() {
+    return this._basicEffortStatus;
+  }
+
+  set basicEffortStatus(basicEffortStatus) {
+    this._basicEffortStatus = basicEffortStatus;
+  }
+
+  get basicIndividualStatus() {
+    return this._basicIndividualStatus;
+  }
+
+  set basicIndividualStatus(basicIndividualStatus) {
+    this._basicIndividualStatus = basicIndividualStatus;
+  }
+
+  get basicTotalStatus() {
+    return this._basicTotalStatus;
+  }
+
+  set basicTotalStatus(basicTotalStatus) {
+    this._basicTotalStatus = basicTotalStatus;
+  }
+
+  get groups() {
+    return this._groups;
+  }
+
+
+  /**
+   * ステータスを計算し、_basicTotalStatusプロパティへ格納
+   * @param _basicPokemonStatus 種族値
+   * @param _basicIndividualStatus 個体値
+   * @param _basicEffortStatus 努力値
+   */
+  calculateBasicStatus(_basicPokemonStatus: IBasicStatus, _basicIndividualStatus: IBasicStatus, _basicEffortStatus: IBasicStatus): void {
+    for (let k of Object.keys(this._basicTotalStatus) as (keyof IBasicStatus)[]) {
+      const common = ((_basicPokemonStatus[k] * 2) + _basicIndividualStatus[k] + _basicEffortStatus[k]) * this._lebel / 100;
+      this._basicTotalStatus[k] = k === 'hp' 
+        ? Math.round(common + this._lebel + 10)
+        : Math.round(common + 5)
+      ;
+    }
+  }
+}

--- a/src/model/pokemon/Pokemon.ts
+++ b/src/model/pokemon/Pokemon.ts
@@ -1,4 +1,3 @@
-import { TBasicStatus } from "../../utils/type/TBasicStatus";
 import { Group } from '../group/Group';
 import { Move } from '../move/Move';
 
@@ -28,116 +27,21 @@ export abstract class Pokemon {
   }[];
 
   /**
-   * 種族値
-   */
-  protected readonly abstract _basicPokemonStatus: TBasicStatus;
-
-  /**
-   * 個体値
-   */
-  protected abstract _basicIndividualStatus: TBasicStatus = {
-    hp: 0,
-    attack: 0,
-    protected: 0,
-    SPattack: 0,
-    SPprotected: 0,
-    rapidity: 0
-  }
-
-  /**
-   * 努力値
-   */
-  protected abstract _basicEffortStatus: TBasicStatus = {
-    hp: 0,
-    attack: 0,
-    protected: 0,
-    SPattack: 0,
-    SPprotected: 0,
-    rapidity: 0
-  }
-
-  /* レベル・わざ・ステータスは、ExceptPokemonとOwnPokemonのインスタンス生成時に必ず
-
-  /**
-   * レベル
-   */
-  protected abstract _lebel: number = 0;
-
-  /**
-   * おぼえているわざ
-   */
-  protected readonly abstract _moveList: Move[] = [];
-  
-  /**
-   * 種族値・個体値・努力値を合わせた決定ステータス
-   */
-  protected abstract _basicTotalStatus: TBasicStatus;
-
-  /**
    * ゲッター・セッター
    */
   get name() {
     return this._name;
   }
 
-  get lebel() {
-    return this._lebel;
-  }
-
-  set lebel(lebel) {
-    this._lebel = lebel;
-  }
-
-  get basicPokemonStatus() {
-    return this._basicPokemonStatus;
-  }
-
-  get basicEffortStatus() {
-    return this._basicEffortStatus;
-  }
-
-  set basicEffortStatus(basicEffortStatus) {
-    this._basicEffortStatus = basicEffortStatus;
-  }
-
-  get basicIndividualStatus() {
-    return this._basicIndividualStatus;
-  }
-
-  set basicIndividualStatus(basicIndividualStatus) {
-    this._basicIndividualStatus = basicIndividualStatus;
-  }
-
-  get basicTotalStatus() {
-    return this._basicTotalStatus;
-  }
-
-  set basicTotalStatus(basicTotalStatus) {
-    this._basicTotalStatus = basicTotalStatus;
-  }
-
   get groups() {
     return this._groups;
   }
 
-  get moveListToRequest() {
-    return this._moveListToRequest;
+  get pokemonType() {
+    return this._pokemonType;
   }
 
-
-  /**
-   * ステータスを計算し、_basicTotalStatusプロパティへ格納
-   * @param _basicPokemonStatus 種族値
-   * @param _basicIndividualStatus 個体値
-   * @param _basicEffortStatus 努力値
-   */
-  calculateBasicStatus(_basicPokemonStatus: TBasicStatus, _basicIndividualStatus: TBasicStatus, _basicEffortStatus: TBasicStatus): void {
-    for (let k of Object.keys(this._basicTotalStatus) as (keyof TBasicStatus)[]) {
-      const common = ((_basicPokemonStatus[k] * 2) + _basicIndividualStatus[k] + _basicEffortStatus[k]) * this._lebel / 100;
-      this._basicTotalStatus[k] = k === 'hp' 
-        ? Math.round(common + this._lebel + 10)
-        : Math.round(common + 5)
-      ;
-    }
+  get moveListToRequest() {
+    return this._moveListToRequest;
   }
 }

--- a/src/model/statusAilment/SaBadPoison.ts
+++ b/src/model/statusAilment/SaBadPoison.ts
@@ -1,0 +1,30 @@
+import { StatusAilment } from './StatusAilment';
+
+export class SaBadPoison extends StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected _name: string = 'もうどく';
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected _sickedMessage: string = 'もうどくをあびた';
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected _alreadySickedMessage: string = 'すでにもうどくにおかされている';
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected _sickedTurnMessage: string = 'もうどくのダメージをうけている';
+
+  /**
+   * 状態異常が回復したときのメッセージ
+   */
+  protected _sickedRecoceryMessage = 'どくがきれいさっぱりなくなった';
+
+}

--- a/src/model/statusAilment/SaBurn.ts
+++ b/src/model/statusAilment/SaBurn.ts
@@ -1,0 +1,30 @@
+import { StatusAilment } from './StatusAilment';
+
+export class SaBurn extends StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected _name: string = 'やけど';
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected _sickedMessage: string = 'やけどをおった';
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected _alreadySickedMessage: string = 'すでにやけどしている';
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected _sickedTurnMessage: string = 'やけどのダメージを受けている';
+
+  /**
+   * 状態異常が回復したときのメッセージ
+   */
+  protected _sickedRecoceryMessage = 'やけどがなおった';
+
+}

--- a/src/model/statusAilment/SaFainting.ts
+++ b/src/model/statusAilment/SaFainting.ts
@@ -1,0 +1,30 @@
+import { StatusAilment } from './StatusAilment';
+
+export class SaFainting extends StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected _name: string = 'ひんし';
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected _sickedMessage: string = 'たおれた';
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected _alreadySickedMessage: string = 'ひんしでうごけない';
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected _sickedTurnMessage: string = 'ひんしでうごけない';
+
+  /**
+   * 状態異常が回復したときのメッセージ
+   */
+  protected _sickedRecoceryMessage = 'ひんしから回復した';
+
+}

--- a/src/model/statusAilment/SaFreeze.ts
+++ b/src/model/statusAilment/SaFreeze.ts
@@ -1,0 +1,30 @@
+import { StatusAilment } from './StatusAilment';
+
+export class SaFreeze extends StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected _name: string = 'こおり';
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected _sickedMessage: string = 'こおりづけになった';
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected _alreadySickedMessage: string = 'すでにこおっている';
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected _sickedTurnMessage: string = 'こおってしまってうごけない';
+
+  /**
+   * 状態異常が回復したときのメッセージ
+   */
+  protected _sickedRecoceryMessage = 'こおりがとけた';
+
+}

--- a/src/model/statusAilment/SaParalysis.ts
+++ b/src/model/statusAilment/SaParalysis.ts
@@ -1,0 +1,30 @@
+import { StatusAilment } from './StatusAilment';
+
+export class SaParalysis extends StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected _name: string = 'まひ';
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected _sickedMessage: string = 'まひしてわざが出にくくなった';
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected _alreadySickedMessage: string = 'すでにまひしている';
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected _sickedTurnMessage: string = 'からだがしびれてうごない';
+
+  /**
+   * 状態異常が回復したときのメッセージ
+   */
+  protected _sickedRecoceryMessage = 'からだのしびれがとれた';
+
+}

--- a/src/model/statusAilment/SaPoison.ts
+++ b/src/model/statusAilment/SaPoison.ts
@@ -1,0 +1,30 @@
+import { StatusAilment } from './StatusAilment';
+
+export class SaPoison extends StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected _name: string = 'どく';
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected _sickedMessage: string = 'どくをあびた';
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected _alreadySickedMessage: string = 'すでにどくにおかされている';
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected _sickedTurnMessage: string = 'どくのダメージをうけている';
+
+  /**
+   * 状態異常が回復したときのメッセージ
+   */
+  protected _sickedRecoceryMessage = 'どくがきれいさっぱりなくなった';
+
+}

--- a/src/model/statusAilment/SaSleep.ts
+++ b/src/model/statusAilment/SaSleep.ts
@@ -1,0 +1,30 @@
+import { StatusAilment } from './StatusAilment';
+
+export class SaSleep extends StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected _name: string = 'ねむり';
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected _sickedMessage: string = 'ねむってしまった';
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected _alreadySickedMessage: string = 'すでにねむっている';
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected _sickedTurnMessage: string = 'ぐうぐうねむっている';
+
+  /**
+   * 状態異常が回復したときのメッセージ
+   */
+  protected _sickedRecoceryMessage = 'めをさました';
+
+}

--- a/src/model/statusAilment/StatusAilment.ts
+++ b/src/model/statusAilment/StatusAilment.ts
@@ -1,0 +1,32 @@
+export abstract class StatusAilment {
+
+  /**
+   * 名前
+   */
+  protected abstract _name: string;
+
+  /**
+   * 状態異常になった時のメッセージ
+   */
+  protected abstract _sickedMessage: string;
+
+  /**
+   * すでに状態異常だったときのメッセージ
+   */
+  protected abstract _alreadySickedMessage: string;
+
+  /**
+   * 状態異常のままターンになったときのメッセージ
+   */
+  protected abstract _sickedTurnMessage: string;
+
+  /**
+   * 状態異常が回復したときのメッセージ
+   */
+  protected abstract _sickedRecoceryMessage: string;
+
+  get name() {
+    return this._name;
+  }
+
+}

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,0 +1,47 @@
+import { Pokemon } from '../model/pokemon/Pokemon';
+
+/**
+ * 配列の中からランダムで返す処理
+ */
+export const randomSingleInArray = <T>(array: T[]): T => {
+  const index = Math.floor(Math.random() * array.length);
+  return array[index];
+}
+
+
+/**
+ * 配列の中から指定した数の要素をランダムで返す処理（重複なし）
+ * @param array 取り出す対象の配列
+ * @param count 取り出したい個数
+ */
+export const randomMultipleInArray = <T>(array: T[], count: number): T[] => {
+  const result = [];
+  for (let i = 0; i < count; i++) {
+    const index = Math.floor(Math.random() * array.length);
+    result[i] = array[index];
+    array.splice(index, 1);
+  }
+  return result;
+}
+
+
+/**
+ * 指定されたポケモンの生成を返す
+ */
+export const getPokemon = <T extends Pokemon>(PokemonType: new (isBeforeEvolve: Pokemon | null, nickname?: string) => T, isBeforeEvolve: Pokemon | null = null, nickname?: string): Pokemon => {
+  return new PokemonType(isBeforeEvolve, nickname);
+}
+
+
+  /**
+   * テキストが規定通りかチェック
+   */
+export const checkImportText = (checkText: string): boolean => {
+  if(checkText
+    && (checkText.match(/^[ぁ-んー　]*$/) || checkText.match(/^[ァ-ヶー　]+$/))
+    && checkText.length <= 5){
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/src/utils/interface/ILebel.ts
+++ b/src/utils/interface/ILebel.ts
@@ -1,0 +1,3 @@
+export interface ILebel {
+  _lebel: number;
+}

--- a/src/utils/interface/IMoveList.ts
+++ b/src/utils/interface/IMoveList.ts
@@ -1,0 +1,5 @@
+import { Move } from '../../model/move/Move';
+
+export interface IMoveList {
+  _moveList: Move[];
+}

--- a/src/utils/interface/IPokemonBattle.ts
+++ b/src/utils/interface/IPokemonBattle.ts
@@ -16,21 +16,4 @@ export interface IPokemonBattle {
    * バトルステータスランク
    */
   _battleStatusRank: TBattleStatusRank;
-
-  /**
-   * 残りHP計算
-   */
-  calculateRemainingHp: (effect: 'saFainting' | 'sub' | 'add' | 'reset', number: number) => number;
-
-  /**
-   * バトルステータスランクの加算・減算
-   */
-  addBattleStatusRank:(key: keyof TBattleStatusRank, number: number) => void;
-  subBattleStatusRank:(key: keyof TBattleStatusRank, number: number) => void;
-
-  /**
-   * ランク補正値の計算
-   */
-  calculateBattleStatusRankCorrection: (key: keyof TBattleStatusRank) => number;
-
 }

--- a/src/utils/interface/IPokemonBattle.ts
+++ b/src/utils/interface/IPokemonBattle.ts
@@ -1,0 +1,35 @@
+import { TBattleStatusRank } from '../type/TBattleStatusRank';
+
+export interface IPokemonBattle {
+  /**
+   * 残りHP
+   */
+  _remainingHp: number;
+
+  /**
+   * 状態異常
+   */
+  _statusAilment: StatusAilment[];
+
+  /**
+   * バトルステータスランク
+   */
+  _battleStatusRank: TBattleStatusRank;
+
+  /**
+   * 残りHP計算
+   */
+  calculateRemainingHp: (effect: 'saFainting' | 'sub' | 'add' | 'reset', number: number) => number;
+
+  /**
+   * バトルステータスランクの加算・減算
+   */
+  addBattleStatusRank:(key: keyof TBattleStatusRank, number: number) => void;
+  subBattleStatusRank:(key: keyof TBattleStatusRank, number: number) => void;
+
+  /**
+   * ランク補正値の計算
+   */
+  calculateBattleStatusRankCorrection: (key: keyof TBattleStatusRank) => number;
+
+}

--- a/src/utils/interface/IPokemonBattle.ts
+++ b/src/utils/interface/IPokemonBattle.ts
@@ -1,4 +1,5 @@
 import { TBattleStatusRank } from '../type/TBattleStatusRank';
+import { StatusAilment } from '../../model/statusAilment/StatusAilment';
 
 export interface IPokemonBattle {
   /**

--- a/src/utils/interface/ISetInitPokemon.ts
+++ b/src/utils/interface/ISetInitPokemon.ts
@@ -1,0 +1,19 @@
+import { TBasicStatus } from '../type/TBasicStatus';
+
+export interface ISetInitPokemon {
+  /**
+   * レベル
+   */
+  _lebel: number;
+
+  /**
+   * おぼえているわざ
+   */
+  _moveList: Move[];
+  
+  /**
+   * 種族値・個体値・努力値を合わせた決定ステータス
+   */
+  _basicTotalStatus: TBasicStatus;
+
+}

--- a/src/utils/interface/IStatus.ts
+++ b/src/utils/interface/IStatus.ts
@@ -1,0 +1,10 @@
+import { TBasicStatus } from '../type/TBasicStatus';
+
+export interface IStatus {
+  _basicTotalStatus: TBasicStatus;
+  _basicIndividualStatus: TBasicStatus;
+  _basicPokemonStatus: TBasicStatus;
+  _basicEffortStatus: TBasicStatus;
+  calculateBasicStatus: () => TBasicStatus;
+  setRandomBasicIndividualStatus: () => TBasicStatus;
+};

--- a/src/utils/interface/IStatus.ts
+++ b/src/utils/interface/IStatus.ts
@@ -6,5 +6,4 @@ export interface IStatus {
   _basicPokemonStatus: TBasicStatus;
   _basicEffortStatus: TBasicStatus;
   calculateBasicStatus: () => TBasicStatus;
-  setRandomBasicIndividualStatus: () => TBasicStatus;
 };

--- a/src/utils/interfaces/IBasicStatus.ts
+++ b/src/utils/interfaces/IBasicStatus.ts
@@ -1,0 +1,8 @@
+export interface IBasicStatus {
+  hp: number,
+  attack: number,
+  protected: number,
+  SPattack: number,
+  SPprotected: number,
+  rapidity: number
+}

--- a/src/utils/type/TBasicStatus.ts
+++ b/src/utils/type/TBasicStatus.ts
@@ -1,4 +1,4 @@
-export interface IBasicStatus {
+export type TBasicStatus = {
   hp: number,
   attack: number,
   protected: number,

--- a/src/utils/type/TBattleStatusRank.ts
+++ b/src/utils/type/TBattleStatusRank.ts
@@ -1,0 +1,10 @@
+export type TBattleStatusRank = {
+  attack: number;
+  protected: number;
+  SPattack: number;
+  SPprotected: number;
+  rapidity: number;
+  critical: number;
+  accuracy: number;
+  evasion: number;
+}


### PR DESCRIPTION
## 行ったこと
* クラス図・ポケモン❸【feature/ポケモンクラス】まで完了
* [クラス図はこちら](https://www.figma.com/file/fnghd4zoiBDaC12mCRdLJD/%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3TS?node-id=63%3A65)

## 概要
* 元々のPokemon.tsが多くの責務を抱えていたため、下記のように変更
* 抽象クラス：ポケモン
  * ポケモン（アチャモ・ミズゴロウ・キモリ等）
    * 手持ちポケモン
    * 敵ポケモン
* interfaceを活用し、無駄がないように工夫。
* StatusAilment / Move / Groupクラスを追加（設計見直し前とほぼ変わらず）。

## 使い方
* 特になし（Fieldクラスが実装されるまではエラーがある）

## UIに対する変更
* 特になし

## その他
* ここまで長かったな