### PR TITLE
basicPokemonStatus忘れを修正 | ownpokemon/exceptpokemonのクラスを移動

### DIFF
--- a/src/model/pokemon/Achamo.ts
+++ b/src/model/pokemon/Achamo.ts
@@ -44,4 +44,16 @@ export class Achamo extends Pokemon {
     // {lebel:36, move: 'きしかいせい'},
     // {lebel:39, move: 'フレアドライブ'}
   ];
+
+  /**
+   * 種族値
+   */
+  _basicPokemonStatus = {
+    hp: 45,
+    attack: 60,
+    protected: 40,
+    SPattack: 70,
+    SPprotected: 50,
+    rapidity: 45
+  };
 }

--- a/src/model/pokemon/ExceptPokemon.ts
+++ b/src/model/pokemon/ExceptPokemon.ts
@@ -69,7 +69,7 @@ export class ExceptPokemon implements ILebel, IStatus, IMoveList, IPokemonBattle
     this._pokemon = pokemon;
     this._lebel = lebel;
 
-    this._basicPokemonStatus = this._pokemon.basicPokemonStatus;
+    this._basicPokemonStatus = this._pokemon._basicPokemonStatus;
     this._basicIndividualStatus = this.setRandomBasicIndividualStatus();
     this._basicTotalStatus = this.calculateBasicStatus();
 

--- a/src/model/pokemon/ExceptPokemon.ts
+++ b/src/model/pokemon/ExceptPokemon.ts
@@ -1,13 +1,13 @@
-import { Pokemon } from "../model/pokemon/Pokemon";
-import { ILebel } from '../utils/interface/ILebel';
-import { IStatus } from '../utils/interface/IStatus';
-import { IMoveList } from '../utils/interface/IMoveList';
-import { IPokemonBattle } from '../utils/interface/IPokemonBattle';
-import { TBasicStatus } from '../utils/type/TBasicStatus';
-import { TBattleStatusRank } from '../utils/type/TBattleStatusRank';
-import { Move } from '../model/move/Move';
-import { randomMultipleInArray } from '../utils/general';
-import { StatusAilment } from '../model/statusAilment/StatusAilment';
+import { Pokemon } from "../../model/pokemon/Pokemon";
+import { ILebel } from '../../utils/interface/ILebel';
+import { IStatus } from '../../utils/interface/IStatus';
+import { IMoveList } from '../../utils/interface/IMoveList';
+import { IPokemonBattle } from '../../utils/interface/IPokemonBattle';
+import { TBasicStatus } from '../../utils/type/TBasicStatus';
+import { TBattleStatusRank } from '../../utils/type/TBattleStatusRank';
+import { Move } from '../../model/move/Move';
+import { randomMultipleInArray } from '../../utils/general';
+import { StatusAilment } from '../../model/statusAilment/StatusAilment';
 
 export class ExceptPokemon implements ILebel, IStatus, IMoveList, IPokemonBattle {
 

--- a/src/model/pokemon/Kimori.ts
+++ b/src/model/pokemon/Kimori.ts
@@ -44,4 +44,16 @@ export class Kimori extends Pokemon {
     // {lebel:36, move: 'がむしゃら'},
     // {lebel:39, move: 'リーフストーム'}
   ];
+
+  /**
+   * 種族値
+   */  
+  _basicPokemonStatus = {
+    hp: 40,
+    attack: 45,
+    protected: 35,
+    SPattack: 65,
+    SPprotected: 55,
+    rapidity: 70
+  };
 }

--- a/src/model/pokemon/Mizugorou.ts
+++ b/src/model/pokemon/Mizugorou.ts
@@ -45,4 +45,16 @@ export class Mizugorou extends Pokemon {
     // {lebel:36, move: 'がむしゃら'},
     // {lebel:39, move: 'ハイドロポンプ'}
   ];
+
+  /**
+   * 種族値
+   */
+  _basicPokemonStatus = {
+    hp: 50,
+    attack: 70,
+    protected: 50,
+    SPattack: 50,
+    SPprotected: 50,
+    rapidity: 40
+  };
 }

--- a/src/model/pokemon/OwnPokemon.ts
+++ b/src/model/pokemon/OwnPokemon.ts
@@ -1,12 +1,12 @@
-import { ExceptPokemon } from "../model/ExceptPokemon";
-import { ILebel } from '../utils/interface/ILebel';
-import { IStatus } from '../utils/interface/IStatus';
-import { IMoveList } from '../utils/interface/IMoveList';
-import { IPokemonBattle } from '../utils/interface/IPokemonBattle';
-import { TBasicStatus } from '../utils/type/TBasicStatus';
-import { TBattleStatusRank } from '../utils/type/TBattleStatusRank';
-import { Move } from '../model/move/Move';
-import { StatusAilment } from '../model/statusAilment/StatusAilment';
+import { ExceptPokemon } from "./ExceptPokemon";
+import { ILebel } from '../../utils/interface/ILebel';
+import { IStatus } from '../../utils/interface/IStatus';
+import { IMoveList } from '../../utils/interface/IMoveList';
+import { IPokemonBattle } from '../../utils/interface/IPokemonBattle';
+import { TBasicStatus } from '../../utils/type/TBasicStatus';
+import { TBattleStatusRank } from '../../utils/type/TBattleStatusRank';
+import { Move } from '../../model/move/Move';
+import { StatusAilment } from '../../model/statusAilment/StatusAilment';
 
 export class OwnPokemon　implements ILebel, IStatus, IMoveList, IPokemonBattle {
   /**

--- a/src/model/pokemon/Pokemon.ts
+++ b/src/model/pokemon/Pokemon.ts
@@ -1,5 +1,6 @@
 import { Group } from '../group/Group';
 import { Move } from '../move/Move';
+import { TBasicStatus } from '../../utils/type/TBasicStatus';
 
 export abstract class Pokemon {
 
@@ -25,6 +26,11 @@ export abstract class Pokemon {
     lebel: number;
     move: Move
   }[];
+
+  /**
+   * 種族値
+   */
+  readonly abstract _basicPokemonStatus: TBasicStatus;
 
   /**
    * ゲッター・セッター


### PR DESCRIPTION
## 行ったこと
* リファクタリング
* basicPokemonStatusの適応漏れ修正

## 概要
* OwnPokemonおよびExceptPokemonを`model/pokemon`直下へ移動。
* basicPokemonStatusが、Pokemonクラスへ実装されていなかったため、追加。

## 使い方
* 特になし

## UIに対する変更
* 特になし

## その他
* 特になし