### PR TITLE
Feature/設計見直し フィールド実装

### DIFF
--- a/src/model/field/EnemyCorpsHideout.ts
+++ b/src/model/field/EnemyCorpsHideout.ts
@@ -1,0 +1,10 @@
+import { Place } from '../field/Place';
+import { Ordinary } from '../human/Ordinary';
+import { Trainer } from '../human/Trainer';
+
+export class EnemyCorpsHideout extends Place {
+
+  constructor(name: string, humans: (Ordinary | Trainer)[]) {
+    super(name, humans);
+  }
+}

--- a/src/model/field/FriendlyShop.ts
+++ b/src/model/field/FriendlyShop.ts
@@ -1,0 +1,17 @@
+import { Place } from '../field/Place';
+import { Ordinary } from '../human/Ordinary';
+import { Trainer } from '../human/Trainer';
+
+import { IBuyItems } from '../../utils/interface/IBuyItems';
+
+export class FriendlyShop extends Place implements IBuyItems {
+
+  constructor(name: string, humans: (Ordinary | Trainer)[]) {
+    super(name, humans);
+  }
+
+  buyItems() :void {
+    return;
+  }
+  
+}

--- a/src/model/field/Gym.ts
+++ b/src/model/field/Gym.ts
@@ -1,0 +1,17 @@
+import { Place } from '../field/Place';
+import { Ordinary } from '../human/Ordinary';
+import { Trainer } from '../human/Trainer';
+import { TGymClassification } from '../../utils/type/TGymClassification';
+
+export class Gym extends Place {
+
+  /**
+   * ジムの分類
+   */
+  _gymClassification: TGymClassification;
+
+  constructor(name: string, humans: (Ordinary | Trainer)[], gymClassification: TGymClassification) {
+    super(name, humans);
+    this._gymClassification = gymClassification;
+  }
+}

--- a/src/model/field/House.ts
+++ b/src/model/field/House.ts
@@ -1,0 +1,10 @@
+import { Place } from '../field/Place';
+import { Ordinary } from '../human/Ordinary';
+import { Trainer } from '../human/Trainer';
+
+export class House extends Place {
+
+  constructor(name: string, humans: (Ordinary | Trainer)[]) {
+    super(name, humans);
+  }
+}

--- a/src/model/field/MapField.ts
+++ b/src/model/field/MapField.ts
@@ -1,34 +1,21 @@
-import { TFieldClassification } from '../../utils/type/TFieldClassification';
-import { TPlaceClassification } from '../../utils/type/TPlaceClassification';
 import { Ordinary } from '../human/Ordinary';
 import { Trainer } from '../human/Trainer';
-import { ExceptPokemon } from '../pokemon/ExceptPokemon';
+import { Place } from '../field/Place';
 
-export abstract class MapField {
+export class MapField {
   /**
    * フィールド名
    */
-  abstract _name: string;
-
-  /**
-   * フィールドの分類
-   */
-  abstract _fieldClassification: TFieldClassification;
+ _name: string;
 
   /**
    * フィールドを構成する場所要素
    */
-  protected abstract readonly _places: {
-    placeClassification: TPlaceClassification;
-    humans?: (Ordinary | Trainer)[];
-    pokemons?: {
-      exceptPokemon: ExceptPokemon;
-      appearingRate: number;
-      lebelRange: number[];
-    }[];
-  }[];
+ _place: Place[];
 
-  get places() {
-    return this._places;
-  }
+ /**
+  * 登場する人物
+  */
+ _humans?: (Ordinary | Trainer)[];
+
 }

--- a/src/model/field/MapField.ts
+++ b/src/model/field/MapField.ts
@@ -20,8 +20,8 @@ export abstract class MapField {
    */
   protected abstract readonly _places: {
     placeClassification: TPlaceClassification;
-    humans: (Ordinary | Trainer)[];
-    pokemons: {
+    humans?: (Ordinary | Trainer)[];
+    pokemons?: {
       exceptPokemon: ExceptPokemon;
       appearingRate: number;
       lebelRange: number[];

--- a/src/model/field/MapField.ts
+++ b/src/model/field/MapField.ts
@@ -1,0 +1,34 @@
+import { TFieldClassification } from '../../utils/type/TFieldClassification';
+import { TPlaceClassification } from '../../utils/type/TPlaceClassification';
+import { Ordinary } from '../human/Ordinary';
+import { Trainer } from '../human/Trainer';
+import { ExceptPokemon } from '../pokemon/ExceptPokemon';
+
+export abstract class MapField {
+  /**
+   * フィールド名
+   */
+  abstract _name: string;
+
+  /**
+   * フィールドの分類
+   */
+  abstract _fieldClassification: TFieldClassification;
+
+  /**
+   * フィールドを構成する場所要素
+   */
+  protected abstract readonly _places: {
+    placeClassification: TPlaceClassification;
+    humans: (Ordinary | Trainer)[];
+    pokemons: {
+      exceptPokemon: ExceptPokemon;
+      appearingRate: number;
+      lebelRange: number[];
+    }[];
+  }[];
+
+  get places() {
+    return this._places;
+  }
+}

--- a/src/model/field/Place.ts
+++ b/src/model/field/Place.ts
@@ -1,0 +1,26 @@
+import { Ordinary } from '../human/Ordinary';
+import { Trainer } from '../human/Trainer';
+
+export abstract class Place {
+  /**
+   * フィールド名
+   */
+  _name: string;
+
+  /**
+   * 登場する人物
+   */
+  _humans?: (Ordinary | Trainer)[];
+
+
+ /**
+  * 登場するアイテム
+  */
+//  items?:{ item: Item, isHide: false }[];
+
+  constructor(name: string, humans: (Ordinary | Trainer)[]) {
+    this._name = name;
+    this._humans = humans;
+  }
+
+}

--- a/src/model/field/PokemonAppearPlace.ts
+++ b/src/model/field/PokemonAppearPlace.ts
@@ -1,0 +1,42 @@
+import { Place } from '../field/Place';
+import { Ordinary } from '../human/Ordinary';
+import { Trainer } from '../human/Trainer';
+import { ExceptPokemon } from '../pokemon/ExceptPokemon';
+import { IWildPokemons } from '../../utils/interface/IWildPokemons';
+import { IPokemonAppearPlaceClassification } from '../../utils/interface/IPokemonAppearPlaceClassification';
+import { TPlaceClassification } from '../../utils/type/TPlaceClassification';
+
+export class PokemonAppearPlace extends Place implements IWildPokemons, IPokemonAppearPlaceClassification {
+
+  /**
+   * 野生ポケモン
+   */
+  _wildPokemons: {
+    trigger: 'すすむ' | 'つりする' | 'はなしかける';
+    exceptPokemon: ExceptPokemon;
+    appearingRate: number;
+    lebelRange: number[];
+  }[];
+
+  /**
+   * 場所の分類
+   */
+  _pokemonAppearPlaceClassification: TPlaceClassification;
+
+  constructor(
+    name: string,
+    humans: (Ordinary | Trainer)[],
+    wildPokemons: {
+      trigger: 'すすむ' | 'つりする' | 'はなしかける';
+      exceptPokemon: ExceptPokemon;
+      appearingRate: number;
+      lebelRange: number[];
+    }[],
+    placeClassification: TPlaceClassification
+  ) {
+    super(name, humans);
+    this._wildPokemons = wildPokemons;
+    this._pokemonAppearPlaceClassification = placeClassification;
+  }
+  
+}

--- a/src/model/field/PokemonCener.ts
+++ b/src/model/field/PokemonCener.ts
@@ -1,0 +1,18 @@
+import { Place } from '../field/Place';
+import { Ordinary } from '../human/Ordinary';
+import { Trainer } from '../human/Trainer';
+import { OwnPokemon } from '../pokemon/OwnPokemon';
+
+import { IRecoverPokemons } from '../../utils/interface/IRecoverPokemons';
+
+export class PokemonCener extends Place implements IRecoverPokemons {
+
+  constructor(name: string, humans: (Ordinary | Trainer)[]) {
+    super(name, humans);
+  }
+
+  recoverPokemons(pokemons: OwnPokemon[]) :void {
+    return;
+  }
+  
+}

--- a/src/model/pokemon/OwnPokemon.ts
+++ b/src/model/pokemon/OwnPokemon.ts
@@ -7,6 +7,7 @@ import { TBasicStatus } from '../../utils/type/TBasicStatus';
 import { TBattleStatusRank } from '../../utils/type/TBattleStatusRank';
 import { Move } from '../../model/move/Move';
 import { StatusAilment } from '../../model/statusAilment/StatusAilment';
+import { MapField } from '../field/MapField';
 
 export class OwnPokemon　implements ILebel, IStatus, IMoveList, IPokemonBattle {
   /**
@@ -37,7 +38,7 @@ export class OwnPokemon　implements ILebel, IStatus, IMoveList, IPokemonBattle 
   /**
    * 出会った場所
    */
-  _encounter: Field.name;
+  _encounter: MapField['_name'];
    
   /**
    * ステータス
@@ -62,7 +63,7 @@ export class OwnPokemon　implements ILebel, IStatus, IMoveList, IPokemonBattle 
    */
   _battleStatusRank: TBattleStatusRank;
 
-  constructor(pokemon: ExceptPokemon, encounterField: Field.name, nickname?: string) {
+  constructor(pokemon: ExceptPokemon, encounterField: MapField['_name'], nickname?: string) {
     this._nickname = nickname ?? pokemon.name;
     this._encounter = encounterField;
 

--- a/src/utils/interface/IBuyItems.ts
+++ b/src/utils/interface/IBuyItems.ts
@@ -1,0 +1,3 @@
+export interface IBuyItems {
+  buyItems: () => void;
+}

--- a/src/utils/interface/IPokemonAppearPlaceClassification.ts
+++ b/src/utils/interface/IPokemonAppearPlaceClassification.ts
@@ -1,0 +1,3 @@
+export interface IPokemonAppearPlaceClassification {
+  pokemonAppearPlaceClassification: '草むら' | '池' | '深いくさむら' | '洞窟の中' | '海';
+}

--- a/src/utils/interface/IPokemonAppearPlaceClassification.ts
+++ b/src/utils/interface/IPokemonAppearPlaceClassification.ts
@@ -1,3 +1,5 @@
+import { TPlaceClassification } from '../type/TPlaceClassification';
+
 export interface IPokemonAppearPlaceClassification {
-  pokemonAppearPlaceClassification: '草むら' | '池' | '深いくさむら' | '洞窟の中' | '海';
+  _pokemonAppearPlaceClassification: TPlaceClassification;
 }

--- a/src/utils/interface/IRecoverPokemons.ts
+++ b/src/utils/interface/IRecoverPokemons.ts
@@ -1,0 +1,3 @@
+export interface IRecoverPokemons {
+  recoverPokemons: () => void;
+}

--- a/src/utils/interface/IRecoverPokemons.ts
+++ b/src/utils/interface/IRecoverPokemons.ts
@@ -1,3 +1,5 @@
+import { OwnPokemon } from '../../model/pokemon/OwnPokemon';
+
 export interface IRecoverPokemons {
-  recoverPokemons: () => void;
+  recoverPokemons: (pokemons: OwnPokemon[]) => void;
 }

--- a/src/utils/interface/IWildPokemons.ts
+++ b/src/utils/interface/IWildPokemons.ts
@@ -1,0 +1,9 @@
+import { ExceptPokemon } from '../../model/pokemon/ExceptPokemon';
+
+export interface IWildPokemons {
+  wildPokemons:{
+    exceptPokemon: ExceptPokemon;
+    appearingRate: number;
+    lebelRange: number[];
+  }[];
+}

--- a/src/utils/interface/IWildPokemons.ts
+++ b/src/utils/interface/IWildPokemons.ts
@@ -1,7 +1,7 @@
 import { ExceptPokemon } from '../../model/pokemon/ExceptPokemon';
 
 export interface IWildPokemons {
-  wildPokemons: {
+  _wildPokemons: {
     trigger: 'すすむ' | 'つりする' | 'はなしかける';
     exceptPokemon: ExceptPokemon;
     appearingRate: number;

--- a/src/utils/interface/IWildPokemons.ts
+++ b/src/utils/interface/IWildPokemons.ts
@@ -1,7 +1,8 @@
 import { ExceptPokemon } from '../../model/pokemon/ExceptPokemon';
 
 export interface IWildPokemons {
-  wildPokemons:{
+  wildPokemons: {
+    trigger: 'すすむ' | 'つりする' | 'はなしかける';
     exceptPokemon: ExceptPokemon;
     appearingRate: number;
     lebelRange: number[];

--- a/src/utils/type/TFieldClassification.ts
+++ b/src/utils/type/TFieldClassification.ts
@@ -1,0 +1,1 @@
+export type TFieldClassification = '森' | '洞窟' | '砂漠' | '道路' | '水道' | 'ビーチ' | '街';

--- a/src/utils/type/TFieldClassification.ts
+++ b/src/utils/type/TFieldClassification.ts
@@ -1,1 +1,0 @@
-export type TFieldClassification = '森' | '洞窟' | '砂漠' | '道路' | '水道' | 'ビーチ' | '街';

--- a/src/utils/type/TGymClassification.ts
+++ b/src/utils/type/TGymClassification.ts
@@ -1,0 +1,7 @@
+import { Group } from '../../model/group/Group';
+
+export type TGymClassification = {
+  order: number;
+  pokemonGroup: Group;
+  badgeName: string;
+}

--- a/src/utils/type/TPlaceClassification.ts
+++ b/src/utils/type/TPlaceClassification.ts
@@ -1,16 +1,1 @@
-export type TPlaceClassification = 
-{ fieldName:'草むら', isWildPokemon: true } |
-{ fieldName:'池', isWildPokemon: true } |
-{ fieldName:'海', isWildPokemon: true } |
-{ fieldName:'洞窟内', isWildPokemon: true } |
-{ fieldName:'深海', isWildPokemon: true } |
-{ fieldName:'深い草むら', isWildPokemon: true } |
-{ fieldName:'その他ポケモン出現フィールド', isWildPokemon: true } |
-{ fieldName:'砂浜', isWildPokemon: false } |
-{ fieldName:'自転車道', isWildPokemon: false } |
-{ fieldName:'民家', isWildPokemon: false } |
-{ fieldName:'ジム', isWildPokemon: false } |
-{ fieldName:'ポケモンセンター', isWildPokemon: false } |
-{ fieldName:'フレンドリーショップ', isWildPokemon: false } |
-{ fieldName:'その他施設', isWildPokemon: false }
-;
+export type TPlaceClassification = '草むら' | '池' | '深いくさむら' | '洞窟の中' | '海';

--- a/src/utils/type/TPlaceClassification.ts
+++ b/src/utils/type/TPlaceClassification.ts
@@ -1,0 +1,16 @@
+export type TPlaceClassification = 
+{ fieldName:'草むら', isWildPokemon: true } |
+{ fieldName:'池', isWildPokemon: true } |
+{ fieldName:'海', isWildPokemon: true } |
+{ fieldName:'洞窟内', isWildPokemon: true } |
+{ fieldName:'深海', isWildPokemon: true } |
+{ fieldName:'深い草むら', isWildPokemon: true } |
+{ fieldName:'その他ポケモン出現フィールド', isWildPokemon: true } |
+{ fieldName:'砂浜', isWildPokemon: false } |
+{ fieldName:'自転車道', isWildPokemon: false } |
+{ fieldName:'民家', isWildPokemon: false } |
+{ fieldName:'ジム', isWildPokemon: false } |
+{ fieldName:'ポケモンセンター', isWildPokemon: false } |
+{ fieldName:'フレンドリーショップ', isWildPokemon: false } |
+{ fieldName:'その他施設', isWildPokemon: false }
+;


### PR DESCRIPTION
## 行ったこと
* Fieldクラス周辺（❸を実装）
* https://www.figma.com/file/fnghd4zoiBDaC12mCRdLJD/%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3TS?node-id=0%3A1

## 概要
* 地図的な役割を果たすMapFieldクラスを追加
* １つのMapFieldを構成する草むら・池・家等の役割を果たす抽象クラスであるPlaceクラス、およびデータとなる草むらや池クラスを追加
* それぞれにインターフェースを紐付け
* Placeクラスを継承した、下記のクラスを作成
  * 野生ポケモンの現れる場所`PokemonAppearPlace`
  * 民家`House`
  * 敵キャラ系のアジト`EnemyCorpsHideout`
  * ポケモンセンター`PokemonCenter`
  * フレンドリーショップ`FriendlyShop`
  * ポケモンジム`Gym`

## 使い方
* 特になし

## UIに対する変更
* 特になし

## その他
* 悩みましたわ〜