### PR TITLE
battleControllerにポケモンがひんし状態になったらバトルを終了するisBattle属性を追加 | 攻撃を自動化

### DIFF
--- a/src/controller/EventController.ts
+++ b/src/controller/EventController.ts
@@ -91,16 +91,11 @@ export class EventController {
 
         const pochiena = new ExceptPokemon(new Pochiena(), 2);
         const battleController = new PokemonBattleController(pochiena);
-        battleController.setBattleAction('たたかう', battleController._onBattle._moveList[0]);
-        battleController.setBattleAction('たたかう', battleController._onBattle._moveList[0]);
-        battleController.setBattleAction('たたかう', battleController._onBattle._moveList[0]);
-        battleController.setBattleAction('たたかう', battleController._onBattle._moveList[0]);
-        battleController.setBattleAction('たたかう', battleController._onBattle._moveList[0]);
-        battleController.setBattleAction('たたかう', battleController._onBattle._moveList[0]);
-        console.log(battleController._onBattle.basicTotalStatus);
-        console.log(battleController._onBattle._battleStatusRank);
-        console.log(battleController._enemy.basicTotalStatus);
-        console.log(battleController._enemy._battleStatusRank);
+
+        while(battleController.isBattle) {
+          battleController.setBattleAction('たたかう', battleController._onBattle._moveList[0]);
+        }
+
         break;
     }
     return result;

--- a/src/controller/PokemonBattleController.ts
+++ b/src/controller/PokemonBattleController.ts
@@ -34,13 +34,23 @@ export class PokemonBattleController {
   /**
    * ダメージ補正値
    */
-  protected damageCorrection: number = 1;
+  private damageCorrection: number = 1;
+
+  /**
+   * バトル中か否か
+   */
+  private _isBattle: boolean;
 
   constructor(enemyPokemon: ExceptPokemon) {
+    this._isBattle = true;
     this._hero = Hero.getInstance();
     this._onBattle = this._hero._onHandPokemons[0];
     this._enemy = enemyPokemon;
     this.renderSerif(`${this._enemy.pokemon.name}があらわれた。いけ、${this._onBattle.pokemon.name}！`)
+  }
+
+  get isBattle() {
+    return this._isBattle;
   }
 
   /**
@@ -48,9 +58,7 @@ export class PokemonBattleController {
    */
   setBattleAction(action: 'にげる' | 'たたかう', onBattleMove?: Move) {
 
-    // どちらかがひんしであればバトルは続けない
-    const isSaFainging = [this._onBattle, this._enemy].some(pokemon => pokemon._statusAilment?.name === 'ひんし');
-    if (isSaFainging) {
+    if (!this._isBattle) {
       this.renderSerif('どっちかのポケモンがひんしだよ！バトルできないよ');
       return;
     }
@@ -161,6 +169,7 @@ export class PokemonBattleController {
 
       if (this.checkPokemonSaFainting(moveAction.defense)) {
         this.renderSerif(`${moveAction.defense.pokemon.name}はたおれた。hpがゼロになったので、バトルが終了した！`);
+        this._isBattle = false;
         return true;
       }
     });
@@ -250,7 +259,7 @@ export class PokemonBattleController {
       if (effect === null) {
         return damage;
       }
-      
+
       if (effect.change === 'statusAilment') {
         const status = effect.status ? effect.status : null;
         if (status !== null) {


### PR DESCRIPTION
## 行ったこと
* `battleController`へ、バトルが行われているかそうでないかを判別する`isBattle`を追加
* イベントコントローラーからの戦うアクションの実装を自動化（`while`文）

## 概要
* 上記の通り

## 使い方
* とくになし

## UIに対する変更
* とくになし

## その他
* 手持ちのポケモンが複数いることを想定していない
  * 手持ちのポケモンも、最初の１体がひんし状態になったら、バトルが終了する
  * 手持ちポケモンがひんし状態になったさいの、いわゆる「目の前が真っ暗になった」の実装がされていない