### PR TITLE
ゲームオーバーの実装 | recoverPokemonのメソッドに状態異常を回復する処理を追加

### DIFF
--- a/src/controller/MainController.ts
+++ b/src/controller/MainController.ts
@@ -105,6 +105,17 @@ export class MainController {
     }
   }
 
+  /**
+   * ゲームオーバー処理
+   */
+  gameOver() {
+    this.renderSerif(`${this._hero.name}には戦えるポケモンがいない。目の前が真っ暗になった`);
+    this._hero._onHandPokemons.forEach(pokemon => {
+      pokemon._remainingHp = pokemon.basicTotalStatus.hp;
+      pokemon._statusAilment = null;
+    });
+  }
+
   renderSerif(serif: any): void{
     console.log(serif);
   }

--- a/src/controller/PokemonBattleController.ts
+++ b/src/controller/PokemonBattleController.ts
@@ -8,6 +8,7 @@ import { StatusAilment } from "../model/statusAilment/StatusAilment";
 import { TBattleStatusRank } from "../utils/type/TBattleStatusRank";
 import { TChangeEffext } from "../utils/type/TChangeEffect";
 import { TMoveActionSet } from "../utils/type/TMoveActionSet";
+import { MainController } from "./MainController";
 
 export class PokemonBattleController {
 
@@ -169,11 +170,34 @@ export class PokemonBattleController {
         this.renderSerif(`${moveAction.defense.pokemon.name}はたおれた。hpがゼロになったので、バトルが終了した！`);
         this._isBattle = false;
         this.resetBattleStatusRank(this._onBattle);
+
+        if (moveAction.defense instanceof ExceptPokemon) {
+          return true;
+        }
+
+        const isBattlablePokemon = this.checkOtherBattlablePokemon();
+        if (isBattlablePokemon) {
+          // [note]: 万が一まだ戦えるポケモンがいた場合、入れ替えor逃げるが選べるよう実装
+          // [todo]: 複数の手持ちポケモンを交換しながら戦えるできるように機能拡張したら実装
+        } else {
+          MainController.getInstance().gameOver();    
+        }
         return true;
       }
     });
     moveActionSet.splice(0);
 
+  }
+
+  /**
+   * 手持ちポケモンの中で戦闘可能なポケモンがいるかを判定
+   * [todo]: たおれたポケモンの他に戦えるポケモンがいればtrueを返す
+   * [note]: １匹のポケモンだけで実装しているので、常にfalseを返している
+   */
+  checkOtherBattlablePokemon() {
+    return this._hero._onHandPokemons.some(pokemon => {
+      return pokemon._remainingHp !== 0
+    });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,5 +117,9 @@ console.log('-------------------------');
 console.log('# コトキタウンでポケモンを回復する');
 MainController.getInstance()._field = kotokiTown;
 MainController.getInstance()._place = kotokiPokemonCenter;
+console.log('# const talk = kotokiPokemonCenter.talkJoisanToRecoverPokemon(...mainController._hero._onHandPokemons);');
 const talk = kotokiPokemonCenter.talkJoisanToRecoverPokemon(...mainController._hero._onHandPokemons);
 MainController.getInstance().renderSerif(talk);
+
+console.log('-------------------------');
+console.log('# 手持ちポケモンがすべてひんしになり、目の前が真っ暗になる');

--- a/src/model/machine/RecoverMachine.ts
+++ b/src/model/machine/RecoverMachine.ts
@@ -8,6 +8,7 @@ export class RecoverMachine {
   public recoverPokemon(...pokemons: OwnPokemon[]) {
     pokemons.forEach(pokemon => {
       pokemon._remainingHp = pokemon.basicTotalStatus.hp;
+      pokemon._statusAilment = null;
     });
   }
 

--- a/src/model/pokemon/Achamo.ts
+++ b/src/model/pokemon/Achamo.ts
@@ -28,9 +28,9 @@ export class Achamo extends Pokemon {
     lebel: number;
     move: Move
   }[] = [
-    {lebel: 1, move: MOVE_CLASS_LIST.hikkaku},
+    // {lebel: 1, move: MOVE_CLASS_LIST.hikkaku},
     {lebel:1, move: MOVE_CLASS_LIST.nakigoe},
-    {lebel:3, move: MOVE_CLASS_LIST.hinoko},
+    // {lebel:3, move: MOVE_CLASS_LIST.hinoko},
     // {lebel:6, move: 'でんこうせっか'},
     // {lebel:9, move: 'ニトロチャージ'},
     // {lebel:12, move: 'みきり'},


### PR DESCRIPTION
## 行ったこと
* 戦闘中に自分のポケモンが負けた場合、ゲームオーバーのリセットをする処理を追加。

## 概要
* ポケモンがひんしになった際に、他のポケモンをチェックするメソッドを導入。
* たたかえるポケモンがいなかった際、MainController内の`gameOver()`メソッドを実行。
* ゲームオーバーになった場合、HPと状態異常を回復した状態へ戻る。

## 使い方
* 特になし

## UIに対する変更
* 特になし

## その他
* メモ・悩んだこと・相談